### PR TITLE
Add Investment Committee Briefing and Investor Profile Insights services

### DIFF
--- a/src/ai/ai.controller.spec.ts
+++ b/src/ai/ai.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AiController } from './ai.controller';
 import { AiService } from './ai.service';
 import { ChatOrchestratorService } from './orchestration/chat-orchestrator.service';
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
 
 jest.mock('../env.ts', () => ({
 	jwtSecret: 'fakeJwtSecretsdadxczxc,mfnlfnvlvnvlzmxcmv',
@@ -21,6 +22,10 @@ const mockChatOrchestratorService = {
 	orchestrate: jest.fn(),
 };
 
+const mockTrackerrScoreService = {
+	getScoreForUser: jest.fn(),
+};
+
 describe('AiController', () => {
 	let controller: AiController;
 
@@ -32,6 +37,10 @@ describe('AiController', () => {
 				{
 					provide: ChatOrchestratorService,
 					useValue: mockChatOrchestratorService,
+				},
+				{
+					provide: TrackerrScoreService,
+					useValue: mockTrackerrScoreService,
 				},
 			],
 		}).compile();
@@ -182,7 +191,31 @@ describe('AiController', () => {
 		expect(response.data?.portfolioSummary?.totalValue).toBe(1000);
 		expect(mockChatOrchestratorService.orchestrate).toHaveBeenCalledWith(
 			'user-123',
-			'Resumo da carteira'
+			'Resumo da carteira',
+			{
+				investorProfile: undefined,
+				copilotFlow: undefined,
+				decisionFlow: undefined,
+			}
+		);
+	});
+
+	it('should return trackerr score payload', async () => {
+		mockTrackerrScoreService.getScoreForUser.mockResolvedValue({
+			status: 'ok',
+			overallScore: 81,
+		});
+
+		const result = await controller.trackerrScore(
+			{ user: { userId: 'user-123' } },
+			{ symbol: 'ITUB4' }
+		);
+
+		expect(result.status).toBe('ok');
+		expect(mockTrackerrScoreService.getScoreForUser).toHaveBeenCalledWith(
+			'user-123',
+			'ITUB4',
+			{ previousPillarScores: undefined }
 		);
 	});
 });

--- a/src/ai/ai.controller.ts
+++ b/src/ai/ai.controller.ts
@@ -20,6 +20,7 @@ import { AiAnalysisRequestDto } from './dto/ai-analysis-request.dto';
 import { IntelligentChatRequestDto } from './intelligence/dto/intelligent-chat-request.dto';
 import { ChatOrchestratorService } from './orchestration/chat-orchestrator.service';
 import { ChatOrchestratorResponse } from './orchestration/chat-orchestrator.types';
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
 
 @Controller('ai')
 @ApiTags('ai')
@@ -27,7 +28,8 @@ import { ChatOrchestratorResponse } from './orchestration/chat-orchestrator.type
 export class AiController {
 	constructor(
 		private readonly aiService: AiService,
-		private readonly chatOrchestratorService: ChatOrchestratorService
+		private readonly chatOrchestratorService: ChatOrchestratorService,
+		private readonly trackerrScoreService: TrackerrScoreService
 	) {}
 
 	/**
@@ -82,7 +84,12 @@ export class AiController {
 			req.user?.userId || req.user?.sub || req.user?._id || req.user?.id;
 		const orchestration = await this.chatOrchestratorService.orchestrate(
 			userId,
-			body?.question || ''
+			body?.question || '',
+			{
+				investorProfile: body?.investorProfile,
+				copilotFlow: body?.copilotFlow,
+				decisionFlow: body?.decisionFlow,
+			}
 		);
 		return {
 			intent: orchestration.intent,
@@ -96,6 +103,24 @@ export class AiController {
 		};
 	}
 
+	@Post('trackerr-score')
+	@UseGuards(JwtAuthGuard)
+	@HttpCode(HttpStatus.OK)
+	async trackerrScore(
+		@Request() req: any,
+		@Body()
+		body: {
+			symbol: string;
+			previousPillarScores?: Record<string, number>;
+		}
+	) {
+		const userId =
+			req.user?.userId || req.user?.sub || req.user?._id || req.user?.id;
+		return this.trackerrScoreService.getScoreForUser(userId, body?.symbol, {
+			previousPillarScores: body?.previousPillarScores as any,
+		});
+	}
+
 	private buildIntelligentMessage(response: ChatOrchestratorResponse): string {
 		const data = response.data || {};
 		switch (response.intent) {
@@ -105,6 +130,8 @@ export class AiController {
 					? `Análise de risco concluída. Score atual da carteira: ${riskScore.toFixed(1)}.`
 					: 'Análise de risco da carteira concluída com os dados disponíveis.';
 			}
+			case 'investment_committee':
+				return 'Comitê de investimento semanal gerado com riscos críticos, recomendações e plano objetivo.';
 			case 'tax_estimation':
 			case 'sell_simulation': {
 				const tax = (data as any)?.sellSimulation?.estimatedTax;

--- a/src/ai/intelligence/dto/intelligent-chat-request.dto.ts
+++ b/src/ai/intelligence/dto/intelligent-chat-request.dto.ts
@@ -1,3 +1,16 @@
 export class IntelligentChatRequestDto {
 	question: string;
+	investorProfile?: 'renda' | 'crescimento' | 'conservador' | 'agressivo';
+	copilotFlow?:
+		| 'sell_asset'
+		| 'rebalance_portfolio'
+		| 'reduce_risk_20'
+		| 'committee_mode';
+	decisionFlow?: {
+		action: 'sell' | 'rebalance' | 'reduce_risk';
+		ticker?: string;
+		targetRiskReductionPct?: number;
+		quantity?: number;
+		sellPrice?: number;
+	};
 }

--- a/src/ai/orchestration/chat-orchestrator.service.spec.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.spec.ts
@@ -20,6 +20,7 @@ describe('ChatOrchestratorService', () => {
 		simulateSell: jest.fn(),
 		detectOpportunities: jest.fn(),
 		simulateFuture: jest.fn(),
+		getTrackerrScore: jest.fn(),
 	} as unknown as UnifiedIntelligenceFacade;
 
 	const mockMarketDataProvider: MarketDataProviderPort = {
@@ -79,6 +80,22 @@ describe('ChatOrchestratorService', () => {
 				],
 			},
 		]);
+		(mockUnifiedFacade.getTrackerrScore as jest.Mock).mockReturnValue({
+			modelVersion: 'trackerr_score_v1',
+			overall: 61,
+			weights: {
+				quality: 0.24,
+				risk: 0.24,
+				valuation: 0.2,
+				fiscal: 0.16,
+				portfolio_fit: 0.16,
+			},
+			pillars: [],
+			explanation: {
+				topPositiveDrivers: [],
+				topNegativeDrivers: [],
+			},
+		});
 	});
 
 	afterEach(() => jest.clearAllMocks());
@@ -1121,6 +1138,7 @@ describe('ChatOrchestratorService', () => {
 					profit: { detected: true, direction: 'up', evidence: [] },
 					margin: { detected: true, direction: 'neutral', evidence: [] },
 					indebtedness: { detected: false, direction: 'unknown', evidence: [] },
+					capex: { detected: true, direction: 'up', evidence: [] },
 					guidance: { detected: true, direction: 'up', evidence: [] },
 					risks: { detected: true, direction: 'down', evidence: [] },
 					toneShift: { detected: true, direction: 'up', evidence: [] },
@@ -1149,6 +1167,7 @@ describe('ChatOrchestratorService', () => {
 					profit: { detected: true, direction: 'down', evidence: [] },
 					margin: { detected: true, direction: 'neutral', evidence: [] },
 					indebtedness: { detected: false, direction: 'unknown', evidence: [] },
+					capex: { detected: true, direction: 'down', evidence: [] },
 					guidance: { detected: true, direction: 'down', evidence: [] },
 					risks: { detected: true, direction: 'up', evidence: [] },
 					toneShift: { detected: true, direction: 'down', evidence: [] },
@@ -1169,5 +1188,137 @@ describe('ChatOrchestratorService', () => {
 		expect((response.data.riComparison as any)?.differences?.guidance).toBe(
 			'improved'
 		);
+		expect((response.data.riComparison as any)?.differences?.capex).toBe(
+			'improved'
+		);
+		expect((response.data.riTimeline as any[] | undefined)?.length).toBe(2);
+		expect((response.data.riComparison as any)?.materialAlerts).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('Capex mudou de down para up'),
+			])
+		);
+		expect((response.data.riComparison as any)?.differences?.keyChanges?.capex)
+			.toEqual({ from: 'down', to: 'up' });
+	});
+
+	it('routes committee flow and returns weekly briefing structure', async () => {
+		(mockUnifiedFacade.getPortfolioSummary as jest.Mock).mockReturnValue({
+			totalValue: 1500,
+			positionsCount: 2,
+		});
+		(mockUnifiedFacade.getPortfolioRiskAnalysis as jest.Mock).mockReturnValue({
+			risk: { score: 62, flags: [{severity: 'high', message: 'Risco alto'}] },
+			concentrationByAsset: [{key: 'ITUB4', percentage: 42, severity: 'high'}],
+			concentrationBySector: [],
+			rebalanceSuggestionInputs: {},
+		});
+		(mockUnifiedFacade.detectOpportunities as jest.Mock).mockResolvedValue({
+			opportunities: [],
+			signals: [],
+			unavailableSymbols: [],
+			warnings: [],
+		});
+		(mockMarketDataProvider.getManyAssetSnapshots as jest.Mock).mockResolvedValue([
+			{
+				symbol: 'ITUB4',
+				assetType: 'stock',
+				sector: 'Financial',
+				price: 30,
+				dividendYield: 0.08,
+				performance: {changePercent: 1},
+				fundamentals: {
+					priceToEarnings: 8,
+					priceToBook: 1,
+					returnOnEquity: 0.2,
+					netMargin: 0.18,
+					evEbitda: 5,
+					marketCap: 100,
+				},
+				metadata: {source: 'primary', fallbackUsed: false, partial: false, fallbackSources: []},
+			},
+		]);
+
+		const service = makeService();
+		const response = await service.orchestrate(
+			'user-1',
+			'gerar briefing semanal',
+			{copilotFlow: 'committee_mode'},
+		);
+
+		expect(response.intent).toBe('investment_committee');
+		expect((response.data.investmentCommittee as any)?.modelVersion).toBe(
+			'investment_committee_v1',
+		);
+		expect((response.data.investmentCommittee as any)?.objectivePlan?.length).toBeGreaterThan(0);
+	});
+
+	it('supports guided reduce_risk flow with deterministic target override', async () => {
+		(mockUnifiedFacade.getPortfolioRiskAnalysis as jest.Mock).mockReturnValue({
+			risk: { score: 80, flags: [] },
+			concentrationByAsset: [{ key: 'ITUB4', symbol: 'ITUB4', severity: 'high' }],
+			concentrationBySector: [{ key: 'Financial', severity: 'high' }],
+		});
+
+		const service = makeService();
+		const response = await service.orchestrate(
+			'user-1',
+			'reduzir risco',
+			{
+				copilotFlow: 'reduce_risk_20',
+				decisionFlow: {
+					action: 'reduce_risk',
+					targetRiskReductionPct: 25,
+				},
+			}
+		);
+
+		expect(response.intent).toBe('portfolio_risk');
+		expect((response.data.rebalancePlan as any)?.targetRiskReductionPct).toBe(25);
+		expect((response.data.rebalancePlan as any)?.targetRiskScore).toBe(60);
+		expect(response.route.type).toBe('deterministic_no_llm');
+	});
+
+	it('returns pre and post trade fiscal details in sell guided flow', async () => {
+		(mockMarketDataProvider.getAssetSnapshot as jest.Mock).mockResolvedValue({
+			symbol: 'ITUB4',
+			assetType: 'stock',
+			sector: 'Financial',
+			price: 130,
+			dividendYield: 0.08,
+			performance: { changePercent: 1.2 },
+			fundamentals: {
+				priceToEarnings: 8,
+				priceToBook: 1,
+				returnOnEquity: 0.2,
+				netMargin: 0.2,
+				evEbitda: 4,
+				marketCap: 10,
+			},
+			metadata: {
+				source: 'primary',
+				fallbackUsed: false,
+				partial: false,
+				fallbackSources: [],
+			},
+		});
+		(mockUnifiedFacade.simulateSell as jest.Mock).mockReturnValue({
+			symbol: 'ITUB4',
+			estimatedTax: 30,
+			taxRateApplied: 0.15,
+			realizedPnl: 200,
+			remainingQuantity: 5,
+			compensationUsed: 0,
+			monthlyExemptionApplied: false,
+			classification: 'tributavel',
+		});
+
+		const service = makeService();
+		const response = await service.orchestrate('user-1', 'Simular venda de ITUB4');
+
+		expect(response.intent).toBe('sell_simulation');
+		expect((response.data.tradePlaybook as any)?.preTrade?.estimatedTax).toBe(30);
+		expect((response.data.tradePlaybook as any)?.preTrade?.taxRateApplied).toBe(15);
+		expect((response.data.tradePlaybook as any)?.postTrade?.estimatedDarf).toBe(30);
+		expect((response.data.tradePlaybook as any)?.preTrade?.alternatives?.length).toBe(3);
 	});
 });

--- a/src/ai/orchestration/chat-orchestrator.service.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.ts
@@ -50,11 +50,42 @@ export class ChatOrchestratorService {
 		question: string,
 		options?: {
 			marketDataVersion?: string | null;
+			investorProfile?:
+				| 'renda'
+				| 'crescimento'
+				| 'conservador'
+				| 'agressivo'
+				| null;
+			copilotFlow?:
+				| 'sell_asset'
+				| 'rebalance_portfolio'
+				| 'reduce_risk_20'
+				| 'committee_mode'
+				| null;
+			decisionFlow?: {
+				action: 'sell' | 'rebalance' | 'reduce_risk';
+				ticker?: string;
+				targetRiskReductionPct?: number;
+				quantity?: number;
+				sellPrice?: number;
+			} | null;
 		}
 	): Promise<ChatOrchestratorResponse> {
 		const normalizedQuestion = String(question || '').trim();
-		const symbols = this.extractSymbols(normalizedQuestion);
-		const intent = this.classifyIntent(normalizedQuestion, symbols);
+		const copilotFlow =
+			options?.copilotFlow ||
+			this.mapDecisionFlowToCopilot(options?.decisionFlow || null);
+		const symbols =
+			options?.decisionFlow?.ticker
+				? [this.normalizeTicker(options.decisionFlow.ticker)]
+				: this.extractSymbols(normalizedQuestion);
+		const investorProfile = this.resolveInvestorProfile(
+			options?.investorProfile || null,
+			normalizedQuestion
+		);
+		const intent = this.classifyIntent(normalizedQuestion, symbols, {
+			copilotFlow: copilotFlow || null,
+		});
 		const predictedRouteType =
 			intent === 'narrative_synthesis' || intent === 'unknown'
 				? 'synthesis_required'
@@ -136,6 +167,18 @@ export class ChatOrchestratorService {
 				this.unifiedIntelligenceFacade.getPortfolioSummary({
 					positions,
 				});
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					portfolioSummary,
+					trackerrScore,
+				},
+			});
 			const response = this.buildResponse({
 				intent,
 				routeType: 'deterministic_no_llm',
@@ -145,7 +188,7 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { portfolioSummary },
+				data: { portfolioSummary, trackerrScore, personalizedInsights },
 				unavailable,
 				warnings,
 				assumptions,
@@ -168,6 +211,33 @@ export class ChatOrchestratorService {
 				this.unifiedIntelligenceFacade.getPortfolioRiskAnalysis({
 					positions,
 				});
+			const rebalancePlan =
+				copilotFlow === 'rebalance_portfolio' ||
+				copilotFlow === 'reduce_risk_20'
+					? this.buildRiskReductionPlan({
+							portfolioRisk,
+							targetRiskReductionPct:
+								copilotFlow === 'reduce_risk_20'
+									? Number(
+											options?.decisionFlow?.action === 'reduce_risk'
+												? options?.decisionFlow?.targetRiskReductionPct || 20
+												: 20
+									  )
+									: 10,
+					  })
+					: null;
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					portfolioRisk,
+					trackerrScore,
+				},
+			});
 			const response = this.buildResponse({
 				intent,
 				routeType: 'deterministic_no_llm',
@@ -177,7 +247,12 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { portfolioRisk },
+				data: {
+					portfolioRisk,
+					trackerrScore,
+					personalizedInsights,
+					...(rebalancePlan ? { rebalancePlan } : {}),
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -416,9 +491,18 @@ export class ChatOrchestratorService {
 			}
 			const position = bySymbol.get(this.normalizeTicker(primarySymbol))!;
 			const parsed = this.parseSellInputs(normalizedQuestion);
+			const decisionFlowSellPrice =
+				options?.decisionFlow?.action === 'sell'
+					? Number(options?.decisionFlow?.sellPrice || 0) || null
+					: null;
+			const decisionFlowQuantity =
+				options?.decisionFlow?.action === 'sell'
+					? Number(options?.decisionFlow?.quantity || 0) || null
+					: null;
 			const snapshot =
 				await this.marketDataProvider.getAssetSnapshot(primarySymbol);
-			const sellPrice = parsed.sellPrice ?? snapshot?.price ?? null;
+			const sellPrice =
+				decisionFlowSellPrice ?? parsed.sellPrice ?? snapshot?.price ?? null;
 			if (sellPrice === null) {
 				unavailable.push(primarySymbol);
 				warnings.push('missing_sell_price_for_simulation');
@@ -450,6 +534,7 @@ export class ChatOrchestratorService {
 			}
 
 			const quantityToSell =
+				decisionFlowQuantity ??
 				parsed.quantityToSell ??
 				(parsed.sellHalfRequested
 					? Number((position.quantity / 2).toFixed(8))
@@ -480,6 +565,28 @@ export class ChatOrchestratorService {
 					totalCost: currentTotalCost,
 				},
 			});
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+				targetSymbol: primarySymbol,
+				targetSnapshot: snapshot || undefined,
+				sellSimulation,
+			});
+			const tradePlaybook = this.buildTradePlaybook({
+				symbol: primarySymbol,
+				positions,
+				targetPosition: position,
+				simulation: sellSimulation,
+				sellPrice,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					sellSimulation,
+					tradePlaybook,
+				},
+			});
 
 			const response = this.buildResponse({
 				intent,
@@ -490,7 +597,13 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { sellSimulation, externalAsset: snapshot || null },
+				data: {
+					sellSimulation,
+					externalAsset: snapshot || null,
+					trackerrScore,
+					tradePlaybook,
+					personalizedInsights,
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -572,9 +685,17 @@ export class ChatOrchestratorService {
 			}
 			const position = bySymbol.get(this.normalizeTicker(primarySymbol))!;
 			const parsed = this.parseSellInputs(normalizedQuestion);
+			const decisionFlowQuantity =
+				options?.decisionFlow?.action === 'sell'
+					? Number(options?.decisionFlow?.quantity || 0) || null
+					: null;
+			const decisionFlowSellPrice =
+				options?.decisionFlow?.action === 'sell'
+					? Number(options?.decisionFlow?.sellPrice || 0) || null
+					: null;
 			const snapshot =
 				await this.marketDataProvider.getAssetSnapshot(primarySymbol);
-			const sellPrice = snapshot?.price || null;
+			const sellPrice = decisionFlowSellPrice ?? snapshot?.price ?? null;
 			if (sellPrice === null) {
 				unavailable.push(primarySymbol);
 				warnings.push('missing_sell_price_for_tax_estimation');
@@ -609,6 +730,7 @@ export class ChatOrchestratorService {
 					? position.totalValue
 					: Number(position.price || 0) * Number(position.quantity || 0);
 			const quantityToSell =
+				decisionFlowQuantity ??
 				parsed.quantityToSell ??
 				(parsed.sellHalfRequested
 					? Number((position.quantity / 2).toFixed(8))
@@ -629,6 +751,28 @@ export class ChatOrchestratorService {
 			} else {
 				assumptions.push('tax_estimation_assumes_full_position_sell');
 			}
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+				targetSymbol: primarySymbol,
+				targetSnapshot: snapshot || undefined,
+				sellSimulation,
+			});
+			const tradePlaybook = this.buildTradePlaybook({
+				symbol: primarySymbol,
+				positions,
+				targetPosition: position,
+				simulation: sellSimulation,
+				sellPrice,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					sellSimulation,
+					tradePlaybook,
+				},
+			});
 			const response = this.buildResponse({
 				intent,
 				routeType: 'deterministic_no_llm',
@@ -638,7 +782,13 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { sellSimulation, externalAsset: snapshot },
+				data: {
+					sellSimulation,
+					externalAsset: snapshot,
+					trackerrScore,
+					tradePlaybook,
+					personalizedInsights,
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -710,6 +860,20 @@ export class ChatOrchestratorService {
 					sector: snapshot.sector,
 				},
 			});
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+				targetSymbol: normalizedSnapshotSymbol,
+				targetSnapshot: snapshot,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					portfolioFit,
+					trackerrScore,
+				},
+			});
 			const response = this.buildResponse({
 				intent,
 				routeType: 'deterministic_no_llm',
@@ -719,7 +883,12 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { portfolioFit, externalAsset: snapshot },
+				data: {
+					portfolioFit,
+					externalAsset: snapshot,
+					trackerrScore,
+					personalizedInsights,
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -806,6 +975,21 @@ export class ChatOrchestratorService {
 					sector: snapshot.sector,
 				},
 			});
+			const trackerrScore = this.unifiedIntelligenceFacade.getTrackerrScore({
+				positions,
+				targetSymbol: normalizedSnapshotSymbol,
+				targetSnapshot: snapshot,
+			});
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: {
+					externalAsset: snapshot,
+					portfolioFit,
+					trackerrScore,
+				},
+			});
 			const response = this.buildResponse({
 				intent,
 				routeType: 'deterministic_no_llm',
@@ -815,7 +999,12 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { externalAsset: snapshot, portfolioFit },
+				data: {
+					externalAsset: snapshot,
+					portfolioFit,
+					trackerrScore,
+					personalizedInsights,
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -899,6 +1088,106 @@ export class ChatOrchestratorService {
 					futureSimulation,
 					dividendProjection: futureSimulation.dividendProjection,
 				},
+				unavailable,
+				warnings,
+				assumptions,
+				cacheKey: canCache ? cacheKey : null,
+				cacheHit,
+				cacheTtlSeconds: canCache ? ttlSeconds : null,
+			});
+			await this.safeStoreCache(canCache, cacheKey, response, ttlSeconds);
+			this.safeRecordCost({
+				routeType: response.route.type,
+				cacheHit,
+				llmEligible: response.route.llmEligible,
+				estimatedLlmCallsAvoided: 0,
+			});
+			return response;
+		}
+
+		if (intent === 'investment_committee') {
+			const portfolioSummary =
+				this.unifiedIntelligenceFacade.getPortfolioSummary({
+					positions,
+				});
+			const portfolioRisk =
+				this.unifiedIntelligenceFacade.getPortfolioRiskAnalysis({
+					positions,
+				});
+			const opportunities =
+				await this.unifiedIntelligenceFacade.detectOpportunities({
+					portfolioPositions: positions,
+					candidateSymbols: positions.map((item) => item.symbol).slice(0, 12),
+				});
+			const topSymbols = positions.map((item) => item.symbol).slice(0, 10);
+			const snapshots = topSymbols.length
+				? await this.marketDataProvider.getManyAssetSnapshots(topSymbols)
+				: [];
+			const scored = snapshots.map((snapshot) => ({
+				symbol: snapshot.symbol,
+				score: this.unifiedIntelligenceFacade.getTrackerrScore({
+					positions,
+					targetSymbol: snapshot.symbol,
+					targetSnapshot: snapshot,
+				}),
+			}));
+			const ranked = scored
+				.slice()
+				.sort((a, b) => (b.score?.overall || 0) - (a.score?.overall || 0));
+			const recommended = ranked.slice(0, 3).map((item) => ({
+				symbol: item.symbol,
+				score: item.score.overall,
+				reasons: item.score.explanation.topPositiveDrivers.slice(0, 2),
+			}));
+			const avoid = ranked
+				.slice()
+				.reverse()
+				.slice(0, 3)
+				.map((item) => ({
+					symbol: item.symbol,
+					score: item.score.overall,
+					reasons: item.score.explanation.topNegativeDrivers.slice(0, 2),
+				}));
+			const investmentCommittee = {
+				modelVersion: 'investment_committee_v1',
+				referenceDate: new Date().toISOString(),
+				criticalRisks: [
+					...portfolioRisk.risk.flags
+						.filter((flag) => flag.severity !== 'low')
+						.slice(0, 3)
+						.map((flag) => flag.message),
+					...portfolioRisk.concentrationByAsset
+						.filter((item) => item.severity === 'high')
+						.slice(0, 2)
+						.map(
+							(item) =>
+								`Concentração elevada em ${item.key} (${item.percentage.toFixed(1)}%).`
+						),
+				].slice(0, 4),
+				recommended,
+				avoid,
+				objectivePlan: [
+					`Reduzir risco agregado da carteira de ${portfolioRisk.risk.score.toFixed(1)} para abaixo de 55 no curto prazo.`,
+					`Priorizar rebalanceamento com base nos sinais de oportunidade (${opportunities.signals.length} sinais ativos).`,
+					`Monitorar execução fiscal para preservar eficiência sobre o patrimônio de ${portfolioSummary.totalValue.toFixed(2)}.`,
+				],
+			};
+			const personalizedInsights = this.buildPersonalizedInsights({
+				investorProfile,
+				intent,
+				question: normalizedQuestion,
+				data: { investmentCommittee },
+			});
+			const response = this.buildResponse({
+				intent,
+				routeType: 'deterministic_no_llm',
+				routeReason: 'rules_resolved',
+				question: normalizedQuestion,
+				symbols,
+				ownedSymbols,
+				externalSymbols,
+				positionsCount: positions.length,
+				data: { investmentCommittee, personalizedInsights },
 				unavailable,
 				warnings,
 				assumptions,
@@ -1119,7 +1408,10 @@ export class ChatOrchestratorService {
 				ownedSymbols,
 				externalSymbols,
 				positionsCount: positions.length,
-				data: { riComparison },
+				data: {
+					riComparison,
+					riTimeline: (riComparison as any)?.timeline || null,
+				},
 				unavailable,
 				warnings,
 				assumptions,
@@ -1289,6 +1581,7 @@ export class ChatOrchestratorService {
 			'portfolio_fit_analysis',
 			'opportunity_radar',
 			'future_scenario',
+			'investment_committee',
 		];
 		if (
 			marketSensitiveIntents.includes(intent) &&
@@ -1310,6 +1603,7 @@ export class ChatOrchestratorService {
 			return 180;
 		if (intent === 'future_scenario') return 180;
 		if (intent === 'opportunity_radar') return 90;
+		if (intent === 'investment_committee') return 300;
 		if (intent === 'ri_summary' || intent === 'ri_comparison') return 120;
 		if (intent === 'asset_comparison') return 90;
 		if (intent === 'sell_simulation' || intent === 'tax_estimation') return 60;
@@ -1389,6 +1683,7 @@ export class ChatOrchestratorService {
 			'portfolio_fit_analysis',
 			'opportunity_radar',
 			'future_scenario',
+			'investment_committee',
 		];
 		if (!marketSensitiveIntents.includes(input.intent)) {
 			return 'not_applicable';
@@ -1400,9 +1695,36 @@ export class ChatOrchestratorService {
 
 	private classifyIntent(
 		question: string,
-		symbols: string[]
+		symbols: string[],
+		options?: {
+			copilotFlow?:
+				| 'sell_asset'
+				| 'rebalance_portfolio'
+				| 'reduce_risk_20'
+				| 'committee_mode'
+				| null;
+		}
 	): ChatOrchestratorIntent {
 		const text = String(question || '').toLowerCase();
+		if (options?.copilotFlow === 'committee_mode') {
+			return 'investment_committee';
+		}
+		if (options?.copilotFlow === 'sell_asset') {
+			return 'sell_simulation';
+		}
+		if (
+			options?.copilotFlow === 'rebalance_portfolio' ||
+			options?.copilotFlow === 'reduce_risk_20'
+		) {
+			return 'portfolio_risk';
+		}
+		if (
+			/\b(comite de investimento|comitê de investimento|briefing semanal|comite semanal)\b/.test(
+				text
+			)
+		) {
+			return 'investment_committee';
+		}
 		if (
 			/\b(explique|explica|estrategia|estratégia|detalhe|por que|porque)\b/.test(
 				text
@@ -1619,6 +1941,24 @@ export class ChatOrchestratorService {
 				return 'worsened';
 			return 'stable';
 		};
+		const keyChanges = {
+			guidance: {
+				from: previous.structuredSignals.guidance.direction,
+				to: current.structuredSignals.guidance.direction,
+			},
+			margin: {
+				from: previous.structuredSignals.margin.direction,
+				to: current.structuredSignals.margin.direction,
+			},
+			debt: {
+				from: previous.structuredSignals.indebtedness.direction,
+				to: current.structuredSignals.indebtedness.direction,
+			},
+			capex: {
+				from: previous.structuredSignals.capex.direction,
+				to: current.structuredSignals.capex.direction,
+			},
+		};
 
 		return {
 			status: 'compared',
@@ -1630,6 +1970,18 @@ export class ChatOrchestratorService {
 				guidance: compareDirection(
 					current.structuredSignals.guidance.direction,
 					previous.structuredSignals.guidance.direction
+				),
+				margin: compareDirection(
+					current.structuredSignals.margin.direction,
+					previous.structuredSignals.margin.direction
+				),
+				debt: compareDirection(
+					current.structuredSignals.indebtedness.direction,
+					previous.structuredSignals.indebtedness.direction
+				),
+				capex: compareDirection(
+					current.structuredSignals.capex.direction,
+					previous.structuredSignals.capex.direction
 				),
 				risks: compareDirection(
 					current.structuredSignals.risks.direction,
@@ -1647,11 +1999,252 @@ export class ChatOrchestratorService {
 					current.structuredSignals.profit.direction,
 					previous.structuredSignals.profit.direction
 				),
+				keyChanges,
 			},
+			materialAlerts: this.buildRiMaterialAlerts(current, previous),
+			timeline: [
+				{
+					documentId: previous.document.id,
+					period: previous.document.period,
+					publishedAt: previous.document.publishedAt,
+					guidance: previous.structuredSignals.guidance.direction,
+					margin: previous.structuredSignals.margin.direction,
+					debt: previous.structuredSignals.indebtedness.direction,
+					capex: previous.structuredSignals.capex.direction,
+				},
+				{
+					documentId: current.document.id,
+					period: current.document.period,
+					publishedAt: current.document.publishedAt,
+					guidance: current.structuredSignals.guidance.direction,
+					margin: current.structuredSignals.margin.direction,
+					debt: current.structuredSignals.indebtedness.direction,
+					capex: current.structuredSignals.capex.direction,
+				},
+			],
 			summaries: {
 				current: current.summary,
 				previous: previous.summary,
 			},
+		};
+	}
+
+	private buildRiMaterialAlerts(
+		current: RiDocumentSummaryOutput,
+		previous: RiDocumentSummaryOutput
+	): string[] {
+		const alerts: string[] = [];
+		const compare = (
+			label: string,
+			currentDirection: 'up' | 'down' | 'neutral' | 'unknown',
+			previousDirection: 'up' | 'down' | 'neutral' | 'unknown'
+		) => {
+			if (
+				currentDirection === 'unknown' ||
+				previousDirection === 'unknown' ||
+				currentDirection === previousDirection
+			) {
+				return;
+			}
+			alerts.push(
+				`${label} mudou de ${previousDirection} para ${currentDirection} entre os dois últimos releases.`
+			);
+		};
+
+		compare(
+			'Guidance',
+			current.structuredSignals.guidance.direction,
+			previous.structuredSignals.guidance.direction
+		);
+		compare(
+			'Margem',
+			current.structuredSignals.margin.direction,
+			previous.structuredSignals.margin.direction
+		);
+		compare(
+			'Dívida',
+			current.structuredSignals.indebtedness.direction,
+			previous.structuredSignals.indebtedness.direction
+		);
+		compare(
+			'Capex',
+			current.structuredSignals.capex.direction,
+			previous.structuredSignals.capex.direction
+		);
+		return alerts.slice(0, 4);
+	}
+
+	private buildTradePlaybook(params: {
+		symbol: string;
+		positions: PortfolioIntelligencePosition[];
+		targetPosition: PortfolioIntelligencePosition;
+		simulation: {
+			estimatedTax: number;
+			taxRateApplied: number;
+			realizedPnl: number;
+			remainingQuantity: number;
+			compensationUsed: number;
+			monthlyExemptionApplied: boolean;
+			classification: string;
+		};
+		sellPrice: number;
+	}) {
+		const totalPortfolioValue = params.positions.reduce(
+			(acc, item) => acc + this.resolvePositionValue(item),
+			0
+		);
+		const beforeValue = this.resolvePositionValue(params.targetPosition);
+		const afterValue = Math.max(0, params.simulation.remainingQuantity * params.sellPrice);
+		const impactPct =
+			totalPortfolioValue > 0
+				? ((beforeValue - afterValue) / totalPortfolioValue) * 100
+				: 0;
+		const sellHalfQty = Number((params.targetPosition.quantity / 2).toFixed(8));
+		const suggestedOrder = params.simulation.monthlyExemptionApplied
+			? 'Priorizar vendas dentro da faixa de isenção mensal antes de zerar posição.'
+			: 'Avaliar venda parcial primeiro para reduzir impacto fiscal imediato.';
+
+			return {
+				preTrade: {
+					estimatedTax: this.safeMoney(params.simulation.estimatedTax),
+					taxRateApplied: this.safeMoney(
+						Number(params.simulation.taxRateApplied || 0) * 100
+					),
+					classification: params.simulation.classification,
+				alternatives: [
+					{
+						action: `Vender ${sellHalfQty} (${params.symbol}) para reduzir imposto potencial.`,
+						rationale: 'Venda parcial tende a reduzir base tributável imediata.',
+					},
+					{
+						action: 'Compensar prejuízo acumulado antes da execução.',
+						rationale:
+							params.simulation.compensationUsed > 0
+								? 'Há compensação aplicada no cenário atual.'
+								: 'Sem compensação aplicada no cenário atual.',
+					},
+					{
+						action: 'Executar ordem em lotes ao longo da janela fiscal.',
+						rationale: suggestedOrder,
+					},
+					],
+					recommendedExecutionOrder: suggestedOrder,
+					explanation:
+						params.simulation.monthlyExemptionApplied
+							? 'Pré-trade com isenção mensal sinalizada.'
+							: 'Pré-trade com imposto estimado pela engine fiscal.',
+				},
+				postTrade: {
+					remainingQuantity: params.simulation.remainingQuantity,
+					positionValueAfterSell: this.safeMoney(afterValue),
+					portfolioImpactPct: this.safeMoney(impactPct),
+					estimatedDarf: this.safeMoney(params.simulation.estimatedTax),
+					explanation:
+						params.simulation.remainingQuantity <= 0
+							? 'Pós-trade indica encerramento da posição.'
+							: 'Pós-trade mantém posição parcialmente aberta.',
+				},
+			};
+		}
+
+	private buildRiskReductionPlan(params: {
+		portfolioRisk: any;
+		targetRiskReductionPct: number;
+	}) {
+		const currentRiskScore = Number(params.portfolioRisk?.risk?.score || 0);
+		const targetRiskScore = Math.max(
+			0,
+			Number(
+				(
+					currentRiskScore *
+					(1 - Math.max(0, params.targetRiskReductionPct) / 100)
+				).toFixed(2)
+			)
+		);
+		const topAsset = params.portfolioRisk?.concentrationByAsset?.[0];
+		const topSector = params.portfolioRisk?.concentrationBySector?.[0];
+		return {
+			modelVersion: 'risk_reduction_plan_v1',
+			currentRiskScore,
+			targetRiskScore,
+			targetRiskReductionPct: params.targetRiskReductionPct,
+			actions: [
+				topAsset
+					? `Reduzir concentração em ${topAsset.symbol || topAsset.key} para aproximar score alvo.`
+					: 'Reduzir posição mais concentrada da carteira.',
+				topSector
+					? `Rebalancear exposição setorial em ${topSector.key}.`
+					: 'Rebalancear exposição entre classes/setores.',
+				'Executar em lotes e reavaliar risco após cada etapa.',
+			],
+		};
+	}
+
+	private resolveInvestorProfile(
+		profile:
+			| 'renda'
+			| 'crescimento'
+			| 'conservador'
+			| 'agressivo'
+			| null,
+		question: string
+	): 'renda' | 'crescimento' | 'conservador' | 'agressivo' {
+		if (profile) return profile;
+		const text = String(question || '').toLowerCase();
+		if (/\b(dividendo|renda passiva|proventos)\b/.test(text)) return 'renda';
+		if (/\b(crescimento|growth|valorizar)\b/.test(text)) return 'crescimento';
+		if (/\b(conservador|baixo risco|preservar)\b/.test(text))
+			return 'conservador';
+		if (/\b(agressivo|alto risco|alavanc)\b/.test(text)) return 'agressivo';
+		return 'conservador';
+	}
+
+	private mapDecisionFlowToCopilot(
+		decisionFlow:
+			| {
+					action: 'sell' | 'rebalance' | 'reduce_risk';
+			  }
+			| null
+	):
+		| 'sell_asset'
+		| 'rebalance_portfolio'
+		| 'reduce_risk_20'
+		| 'committee_mode'
+		| null {
+		if (!decisionFlow) return null;
+		if (decisionFlow.action === 'sell') return 'sell_asset';
+		if (decisionFlow.action === 'rebalance') return 'rebalance_portfolio';
+		if (decisionFlow.action === 'reduce_risk') return 'reduce_risk_20';
+		return null;
+	}
+
+	private buildPersonalizedInsights(params: {
+		investorProfile: 'renda' | 'crescimento' | 'conservador' | 'agressivo';
+		intent: ChatOrchestratorIntent;
+		question: string;
+		data: Record<string, unknown>;
+	}) {
+		const base =
+			params.investorProfile === 'renda'
+				? 'Priorize previsibilidade de fluxo e estabilidade de caixa.'
+				: params.investorProfile === 'crescimento'
+					? 'Foque na expansão de lucro e ganho de valor no longo prazo.'
+					: params.investorProfile === 'agressivo'
+						? 'Aceite maior volatilidade em troca de potencial de retorno superior.'
+						: 'Preserve capital e mantenha volatilidade sob controle.';
+		const action =
+			params.intent === 'sell_simulation' || params.intent === 'tax_estimation'
+				? 'Revise o pré-trade e execute primeiro o cenário de menor custo fiscal.'
+				: params.intent === 'portfolio_risk'
+					? 'Ajuste concentração e rebalanceie para reduzir risco agregado.'
+					: params.intent === 'investment_committee'
+						? 'Execute o plano semanal por prioridade e monitore riscos críticos.'
+						: 'Use os drivers do Trackerr Score para decidir próxima alocação.';
+
+		return {
+			profile: params.investorProfile,
+			narrative: base,
+			recommendedAction: action,
 		};
 	}
 
@@ -1671,6 +2264,11 @@ export class ChatOrchestratorService {
 		const parsed = new Date(value);
 		if (!Number.isFinite(parsed.getTime())) return null;
 		return parsed.toISOString();
+	}
+
+	private safeMoney(value: number): number {
+		if (!Number.isFinite(value)) return 0;
+		return Number(value.toFixed(2));
 	}
 
 	private toPositions(assets: any[]): PortfolioIntelligencePosition[] {

--- a/src/ai/orchestration/chat-orchestrator.types.ts
+++ b/src/ai/orchestration/chat-orchestrator.types.ts
@@ -15,6 +15,7 @@ export type ChatOrchestratorIntent =
 	| 'opportunity_radar'
 	| 'ri_summary'
 	| 'ri_comparison'
+	| 'investment_committee'
 	| 'narrative_synthesis'
 	| 'unknown';
 
@@ -61,6 +62,12 @@ export interface ChatOrchestratorResponse {
 		futureSimulation?: unknown;
 		riSummary?: unknown;
 		riComparison?: unknown;
+		trackerrScore?: unknown;
+		tradePlaybook?: unknown;
+		riTimeline?: unknown;
+		rebalancePlan?: unknown;
+		personalizedInsights?: unknown;
+		investmentCommittee?: unknown;
 	};
 	unavailable: string[];
 	warnings: string[];

--- a/src/intelligence/application/investment-committee-briefing.service.spec.ts
+++ b/src/intelligence/application/investment-committee-briefing.service.spec.ts
@@ -1,0 +1,30 @@
+import { InvestmentCommitteeBriefingService } from 'src/intelligence/application/investment-committee-briefing.service';
+
+describe('InvestmentCommitteeBriefingService', () => {
+	it('builds weekly briefing with risks, recommend and avoid lists', async () => {
+		const facadeMock = {
+			getPortfolioRiskAnalysis: jest.fn().mockReturnValue({
+				risk: { score: 72, level: 'high', flags: [{ severity: 'high', message: 'Concentração elevada em setor financeiro.' }] },
+				concentrationByAsset: [
+					{ key: 'ITUB4', severity: 'high' },
+					{ key: 'BBDC4', severity: 'medium' },
+					{ key: 'PETR4', severity: 'medium' },
+				],
+			}),
+			detectOpportunities: jest.fn().mockResolvedValue({
+				opportunities: [{ symbol: 'WEGE3' }, { symbol: 'TAEE11' }, { symbol: 'EGIE3' }],
+				warnings: [],
+			}),
+		} as any;
+		const service = new InvestmentCommitteeBriefingService(facadeMock);
+		const result = await service.generate({
+			plan: 'global_investor',
+			positions: [],
+			watchlistSymbols: ['WEGE3'],
+		});
+
+		expect(result.recommendedAssets).toHaveLength(3);
+		expect(result.avoidAssets).toHaveLength(3);
+		expect(result.weeklyObjectivePlan).toHaveLength(3);
+	});
+});

--- a/src/intelligence/application/investment-committee-briefing.service.ts
+++ b/src/intelligence/application/investment-committee-briefing.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { UnifiedIntelligenceFacade } from 'src/intelligence/application/unified-intelligence.facade';
+import { PortfolioIntelligencePosition } from 'src/portfolio/intelligence/domain/portfolio-intelligence.types';
+
+export interface InvestmentCommitteeBriefingInput {
+	plan: string;
+	positions: PortfolioIntelligencePosition[];
+	watchlistSymbols?: string[];
+}
+
+export interface InvestmentCommitteeBriefingOutput {
+	status: 'ok' | 'degraded';
+	plan: string;
+	risksCritical: string[];
+	recommendedAssets: string[];
+	avoidAssets: string[];
+	weeklyObjectivePlan: string[];
+	warnings: string[];
+}
+
+@Injectable()
+export class InvestmentCommitteeBriefingService {
+	constructor(
+		private readonly unifiedIntelligenceFacade: UnifiedIntelligenceFacade
+	) {}
+
+	async generate(
+		input: InvestmentCommitteeBriefingInput
+	): Promise<InvestmentCommitteeBriefingOutput> {
+		const warnings: string[] = [];
+		const normalizedPlan = String(input.plan || 'free').toLowerCase();
+		if (normalizedPlan !== 'global_investor') {
+			warnings.push('committee_mode_requires_global_investor');
+		}
+
+		const risk = this.unifiedIntelligenceFacade.getPortfolioRiskAnalysis({
+			positions: input.positions,
+		});
+		const opportunities = await this.unifiedIntelligenceFacade.detectOpportunities({
+			portfolioPositions: input.positions,
+			candidateSymbols: input.watchlistSymbols,
+		});
+
+		const risksCritical = risk.risk.flags
+			.filter((flag) => flag.severity !== 'low')
+			.slice(0, 3)
+			.map((flag) => flag.message);
+
+		const recommendedAssets = Array.from(
+			new Set(
+				opportunities.opportunities
+					.map((item) => item.symbol)
+					.filter(Boolean)
+			)
+		).slice(0, 3);
+
+		const avoidAssets = risk.concentrationByAsset
+			.filter((item) => item.severity !== 'low')
+			.map((item) => item.key)
+			.slice(0, 3);
+
+		if (recommendedAssets.length < 3) {
+			warnings.push('committee_recommendations_partial');
+		}
+		if (avoidAssets.length < 3) {
+			warnings.push('committee_avoid_list_partial');
+		}
+
+		const weeklyObjectivePlan = [
+			'Reduzir concentração dos ativos com maior risco específico.',
+			'Executar 1 rebalanceamento tático com validação fiscal pré-trade.',
+			'Revisar oportunidades com melhor fit antes de novas compras.',
+		];
+
+		return {
+			status: warnings.length ? 'degraded' : 'ok',
+			plan: normalizedPlan,
+			risksCritical,
+			recommendedAssets,
+			avoidAssets,
+			weeklyObjectivePlan,
+			warnings: Array.from(new Set([...warnings, ...opportunities.warnings])),
+		};
+	}
+}

--- a/src/intelligence/application/investor-profile-insights.service.spec.ts
+++ b/src/intelligence/application/investor-profile-insights.service.spec.ts
@@ -1,0 +1,43 @@
+import { InvestorProfileInsightsService } from 'src/intelligence/application/investor-profile-insights.service';
+
+describe('InvestorProfileInsightsService', () => {
+	it('returns profile-specific narrative for renda', () => {
+		const service = new InvestorProfileInsightsService();
+		const result = service.generate({
+			profile: 'renda',
+			portfolioSummary: {
+				totalValue: 100000,
+				positionsCount: 3,
+				allocationByClass: [],
+				allocationByAsset: [],
+				allocationByGeography: [],
+				diversification: { score: 60, maxScore: 100, status: 'moderate', components: { assetSpread: 1, classSpread: 1, sectorSpread: 1 } },
+				dividendProjection: {
+					modelVersion: 'deterministic_v1',
+					projectedAnnualIncome: 12000,
+					projectedMonthlyIncome: 1000,
+					projectedYieldOnPortfolioPct: 12,
+					coverage: { positionsWithData: 3, positionsWithoutData: 0, dataCoveragePct: 100 },
+					byAssetClass: [],
+				},
+			},
+			portfolioRisk: {
+				risk: { score: 45, level: 'low', flags: [] },
+				concentrationByAsset: [],
+				concentrationBySector: [],
+				rebalanceSuggestionInputs: {
+					modelVersion: 'rebalance_inputs_v1',
+					hasTargetAllocation: false,
+					classAllocationSignals: [],
+					assetConcentrationSignals: [],
+					sectorLimitSignals: [],
+					exposureImbalances: [],
+					hasRelevantSignals: false,
+				},
+			},
+		});
+		expect(result.profile).toBe('renda');
+		expect(result.narrative).toContain('Renda anual estimada');
+		expect(result.status).toBe('degraded');
+	});
+});

--- a/src/intelligence/application/investor-profile-insights.service.ts
+++ b/src/intelligence/application/investor-profile-insights.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { TrackerrScoreOutput } from 'src/intelligence/application/trackerr-score.types';
+import {
+	UnifiedPortfolioRiskOutput,
+	UnifiedPortfolioSummaryOutput,
+} from 'src/intelligence/application/unified-intelligence.types';
+
+export type InvestorProfile =
+	| 'renda'
+	| 'crescimento'
+	| 'conservador'
+	| 'agressivo';
+
+export interface InvestorProfileInsightsInput {
+	profile: InvestorProfile;
+	portfolioSummary: UnifiedPortfolioSummaryOutput;
+	portfolioRisk: UnifiedPortfolioRiskOutput;
+	trackerrScore?: TrackerrScoreOutput | null;
+}
+
+export interface InvestorProfileInsightsOutput {
+	profile: InvestorProfile;
+	status: 'ok' | 'degraded';
+	narrative: string;
+	recommendations: string[];
+	warnings: string[];
+}
+
+@Injectable()
+export class InvestorProfileInsightsService {
+	generate(input: InvestorProfileInsightsInput): InvestorProfileInsightsOutput {
+		const warnings: string[] = [];
+		const totalValue = Number(input.portfolioSummary?.totalValue || 0);
+		const riskScore = Number(input.portfolioRisk?.risk?.score || 0);
+		const dividendAnnual = Number(
+			input.portfolioSummary?.dividendProjection?.projectedAnnualIncome || 0
+		);
+		const score = input.trackerrScore?.overallScore ?? null;
+
+		if (!input.trackerrScore) {
+			warnings.push('profile_insight_trackerr_score_unavailable');
+		}
+
+		if (input.profile === 'renda') {
+			return {
+				profile: input.profile,
+				status: warnings.length ? 'degraded' : 'ok',
+				narrative: `Perfil renda: foco em fluxo previsível. Renda anual estimada da carteira: R$ ${dividendAnnual.toFixed(2)}.`,
+				recommendations: [
+					'Priorizar ativos com histórico de distribuição consistente.',
+					'Evitar giro excessivo para reduzir atrito fiscal.',
+					`Monitorar risco agregado (score atual: ${riskScore.toFixed(1)}).`,
+				],
+				warnings,
+			};
+		}
+
+		if (input.profile === 'crescimento') {
+			return {
+				profile: input.profile,
+				status: warnings.length ? 'degraded' : 'ok',
+				narrative: `Perfil crescimento: busca expansão de capital com controle de risco. Patrimônio monitorado: R$ ${totalValue.toFixed(2)}.`,
+				recommendations: [
+					'Usar rebalanceamento para evitar concentração excessiva em winners.',
+					'Priorizar ativos com melhora em qualidade e valuation no Trackerr Score.',
+					typeof score === 'number'
+						? `Trackerr Score atual do ativo analisado: ${score.toFixed(1)}.`
+						: 'Trackerr Score indisponível para o ativo solicitado.',
+				],
+				warnings,
+			};
+		}
+
+		if (input.profile === 'conservador') {
+			return {
+				profile: input.profile,
+				status: warnings.length ? 'degraded' : 'ok',
+				narrative: `Perfil conservador: preservação de capital com volatilidade controlada. Risco atual: ${riskScore.toFixed(1)}.`,
+				recommendations: [
+					'Reduzir posições com concentração acima do limite interno.',
+					'Favorecer caixa/dividendos com previsibilidade.',
+					'Rever cenário fiscal antes de vendas completas.',
+				],
+				warnings,
+			};
+		}
+
+		return {
+			profile: input.profile,
+			status: warnings.length ? 'degraded' : 'ok',
+			narrative: `Perfil agressivo: maior tolerância a risco com disciplina de execução. Risco atual: ${riskScore.toFixed(1)}.`,
+			recommendations: [
+				'Explorar oportunidades com upside alto, mantendo controle de drawdown.',
+				'Aplicar gatilhos de redução tática quando risco exceder meta.',
+				typeof score === 'number'
+					? `Usar reason codes do Trackerr Score para decisões táticas (score ${score.toFixed(1)}).`
+					: 'Usar dados de risco e concentração enquanto score detalhado estiver indisponível.',
+			],
+			warnings,
+		};
+	}
+}

--- a/src/intelligence/application/trackerr-score.service.spec.ts
+++ b/src/intelligence/application/trackerr-score.service.spec.ts
@@ -1,0 +1,85 @@
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
+
+describe('TrackerrScoreService', () => {
+	const service = new TrackerrScoreService(
+		{} as any,
+		{} as any,
+		{} as any,
+		{} as any
+	);
+
+	it('calculates explainable score with visible weights and reason codes', () => {
+		const output = service.computeScore({
+			symbol: 'ITUB4',
+			assetType: 'stock',
+			qualityMetrics: {
+				roe: 20,
+				netMargin: 0.2,
+				dividendYield: 0.07,
+			},
+			riskMetrics: {
+				changePercent24h: 1.2,
+				concentrationPct: 7,
+			},
+			valuationMetrics: {
+				priceToEarnings: 10,
+				priceToBook: 1.2,
+			},
+			fiscalMetrics: {
+				estimatedTaxRateOnPnl: 0,
+				estimatedTaxAbsolute: 0,
+				monthlyExemptionApplied: true,
+				hasOwnedPosition: true,
+			},
+			portfolioFitMetrics: {
+				fitClassification: 'bom',
+				diversificationDeltaScore: 4,
+			},
+		});
+
+		expect(output.weights.qualidade).toBe(0.25);
+		expect(output.weights.portfolio_fit).toBe(0.2);
+		expect(output.pillars).toHaveLength(5);
+		expect(output.reasonCodes.upward.length).toBeGreaterThan(0);
+		expect(output.overallScore).toBeGreaterThan(0);
+	});
+
+	it('returns downward reason codes when previous pillar scores are higher', () => {
+		const output = service.computeScore({
+			symbol: 'ITUB4',
+			assetType: 'stock',
+			qualityMetrics: {
+				roe: 6,
+				netMargin: 0.03,
+				dividendYield: 0,
+			},
+			riskMetrics: {
+				changePercent24h: 8,
+				concentrationPct: 30,
+			},
+			valuationMetrics: {
+				priceToEarnings: 30,
+				priceToBook: 4,
+			},
+			fiscalMetrics: {
+				estimatedTaxRateOnPnl: 0.15,
+				estimatedTaxAbsolute: 500,
+				monthlyExemptionApplied: false,
+				hasOwnedPosition: true,
+			},
+			portfolioFitMetrics: {
+				fitClassification: 'ruim',
+				diversificationDeltaScore: -4,
+			},
+			previousPillarScores: {
+				qualidade: 80,
+				risco: 70,
+				valuation: 70,
+				fiscal: 70,
+				portfolio_fit: 70,
+			},
+		});
+
+		expect(output.reasonCodes.downward).toContain('score_down_qualidade_vs_previous');
+	});
+});

--- a/src/intelligence/application/trackerr-score.service.ts
+++ b/src/intelligence/application/trackerr-score.service.ts
@@ -1,0 +1,479 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+	MARKET_DATA_PROVIDER,
+	MarketDataProviderPort,
+} from 'src/market-data/application/market-data-provider.port';
+import { PortfolioIntelligenceService } from 'src/portfolio/intelligence/application/portfolio-intelligence.service';
+import { PortfolioService } from 'src/portfolio/portfolio.service';
+import { TradeDecisionService } from 'src/intelligence/application/trade-decision.service';
+import {
+	TrackerrScoreInput,
+	TrackerrScoreOutput,
+	TrackerrScorePillar,
+	TrackerrScoreReasonCode,
+} from 'src/intelligence/application/trackerr-score.types';
+
+const PILLAR_WEIGHTS: Record<TrackerrScorePillar, number> = {
+	qualidade: 0.25,
+	risco: 0.2,
+	valuation: 0.2,
+	fiscal: 0.15,
+	portfolio_fit: 0.2,
+};
+
+@Injectable()
+export class TrackerrScoreService {
+	constructor(
+		private readonly portfolioService: PortfolioService,
+		private readonly portfolioIntelligenceService: PortfolioIntelligenceService,
+		private readonly tradeDecisionService: TradeDecisionService,
+		@Inject(MARKET_DATA_PROVIDER)
+		private readonly marketDataProvider: MarketDataProviderPort
+	) {}
+
+	async getScoreForUser(
+		userId: string,
+		symbol: string,
+		input?: {
+			previousPillarScores?: Partial<Record<TrackerrScorePillar, number>>;
+		}
+	): Promise<TrackerrScoreOutput> {
+		const normalizedSymbol = String(symbol || '').trim().toUpperCase();
+		const warnings: string[] = [];
+		const portfolios = await this.portfolioService.getUserPortfolios(userId);
+		const assets = portfolios.flatMap((portfolio: any) =>
+			Array.isArray(portfolio?.assets) ? portfolio.assets : []
+		);
+		const positions = assets
+			.map((asset: any) => ({
+				symbol: String(asset?.symbol || '').toUpperCase(),
+				assetType: asset?.type || 'other',
+				quantity: Number(asset?.quantity || 0),
+				totalValue:
+					typeof asset?.total === 'number'
+						? Number(asset.total)
+						: Number(asset?.price || 0) * Number(asset?.quantity || 0),
+				price: Number(asset?.price || 0),
+				sector: typeof asset?.sector === 'string' ? asset.sector : null,
+			}))
+			.filter((position) => !!position.symbol);
+		const ownedPosition = positions.find(
+			(position) => position.symbol === normalizedSymbol
+		);
+
+		const snapshot = await this.marketDataProvider.getAssetSnapshot(normalizedSymbol);
+		if (!snapshot) {
+			warnings.push('trackerr_score_market_data_unavailable');
+		}
+
+		const totalValue = positions.reduce(
+			(sum, position) => sum + Number(position.totalValue || 0),
+			0
+		);
+		const concentrationPct =
+			totalValue > 0 && ownedPosition
+				? Number((((ownedPosition.totalValue || 0) / totalValue) * 100).toFixed(2))
+				: null;
+
+		let fiscalEstimatedTax = 0;
+		let fiscalTaxRate = 0;
+		let fiscalMonthlyExemptionApplied = false;
+		if (ownedPosition && snapshot?.price) {
+			const decision = this.tradeDecisionService.buildPreAndPostTrade({
+				symbol: normalizedSymbol,
+				assetType: (ownedPosition.assetType as any) || 'other',
+				quantityToSell: Number(ownedPosition.quantity || 0),
+				sellPrice: Number(snapshot.price || 0),
+				simulatedSellDate: new Date().toISOString(),
+				currentPosition: {
+					quantity: Number(ownedPosition.quantity || 0),
+					totalCost: Number(ownedPosition.totalValue || 0),
+				},
+				totalPortfolioValue: totalValue,
+			});
+			fiscalEstimatedTax = decision.preTrade.estimatedTax;
+			fiscalTaxRate = decision.preTrade.taxRateApplied;
+			fiscalMonthlyExemptionApplied =
+				decision.preTrade.explanation.includes('isenção');
+		}
+
+		let fitClassification: 'bom' | 'neutro' | 'ruim' | 'unknown' = 'unknown';
+		let diversificationDeltaScore: number | null = null;
+		if (snapshot?.price && positions.length > 0) {
+			const fit = this.portfolioIntelligenceService.analyzePortfolioFit(
+				positions as any,
+				{
+					symbol: normalizedSymbol,
+					assetType: snapshot.assetType,
+					quantity: ownedPosition?.quantity || 1,
+					totalValue:
+						ownedPosition?.totalValue || Number(snapshot.price || 0),
+					currentPrice: Number(snapshot.price || 0),
+					sector: snapshot.sector,
+				}
+			);
+			fitClassification = fit.classification;
+			diversificationDeltaScore = Number(
+				fit.impact?.diversification?.deltaScore || 0
+			);
+		} else {
+			warnings.push('trackerr_score_portfolio_fit_partial');
+		}
+
+		const score = this.computeScore({
+			symbol: normalizedSymbol,
+			assetType: (snapshot?.assetType as any) || (ownedPosition?.assetType as any) || 'other',
+			qualityMetrics: {
+				roe: snapshot?.fundamentals?.returnOnEquity ?? null,
+				netMargin: snapshot?.fundamentals?.netMargin ?? null,
+				dividendYield: snapshot?.dividendYield ?? null,
+			},
+			riskMetrics: {
+				changePercent24h: snapshot?.performance?.changePercent ?? null,
+				concentrationPct,
+			},
+			valuationMetrics: {
+				priceToEarnings: snapshot?.fundamentals?.priceToEarnings ?? null,
+				priceToBook: snapshot?.fundamentals?.priceToBook ?? null,
+			},
+			fiscalMetrics: {
+				estimatedTaxRateOnPnl: fiscalTaxRate || null,
+				estimatedTaxAbsolute: fiscalEstimatedTax || null,
+				monthlyExemptionApplied: fiscalMonthlyExemptionApplied,
+				hasOwnedPosition: Boolean(ownedPosition),
+			},
+			portfolioFitMetrics: {
+				fitClassification,
+				diversificationDeltaScore,
+			},
+			previousPillarScores: input?.previousPillarScores,
+		});
+
+		if (snapshot?.metadata?.partial) warnings.push('trackerr_score_partial_market_data');
+		if (snapshot?.metadata?.fallbackUsed) warnings.push('trackerr_score_fallback_market_data');
+
+		return {
+			...score,
+			status: warnings.length > 0 ? 'degraded' : 'ok',
+			warnings: Array.from(new Set([...score.warnings, ...warnings])),
+		};
+	}
+
+	computeScore(input: TrackerrScoreInput): TrackerrScoreOutput {
+		const quality = this.computeQualityScore(input);
+		const risk = this.computeRiskScore(input);
+		const valuation = this.computeValuationScore(input);
+		const fiscal = this.computeFiscalScore(input);
+		const fit = this.computePortfolioFitScore(input);
+
+		const pillars = [quality, risk, valuation, fiscal, fit].map((pillar) => ({
+			...pillar,
+			weightedScore: Number((pillar.score * PILLAR_WEIGHTS[pillar.pillar]).toFixed(2)),
+		}));
+
+		const overallScore = Number(
+			pillars
+				.reduce((sum, pillar) => sum + pillar.weightedScore, 0)
+				.toFixed(2)
+		);
+
+		const scoreDirectionReasons = this.buildScoreDirectionReasons(input, pillars);
+
+		return {
+			symbol: input.symbol,
+			assetType: input.assetType,
+			status: 'ok',
+			overall: overallScore,
+			overallScore,
+			weights: PILLAR_WEIGHTS,
+			pillars,
+			reasonCodes: scoreDirectionReasons,
+			warnings: [],
+			explanation: {
+				summary: `Trackerr Score calculado com pilares fixos e pesos visíveis. Resultado atual: ${overallScore}/100.`,
+				topPositiveDrivers: pillars
+					.flatMap((pillar) => pillar.reasonCodes)
+					.filter((reason) => reason.direction === 'up')
+					.map((reason) => reason.description)
+					.slice(0, 3),
+				topNegativeDrivers: pillars
+					.flatMap((pillar) => pillar.reasonCodes)
+					.filter((reason) => reason.direction === 'down')
+					.map((reason) => reason.description)
+					.slice(0, 3),
+			},
+		};
+	}
+
+	build(input: any): TrackerrScoreOutput {
+		if (input?.qualityMetrics) {
+			return this.computeScore(input as TrackerrScoreInput);
+		}
+		const positions = Array.isArray(input?.positions) ? input.positions : [];
+		const targetSymbol =
+			String(input?.targetSymbol || positions?.[0]?.symbol || 'PORTFOLIO').toUpperCase();
+		const targetSnapshot = input?.targetSnapshot;
+		const targetPosition =
+			positions.find(
+				(position: any) =>
+					String(position?.symbol || '').toUpperCase() === targetSymbol
+			) || null;
+		const totalValue = positions.reduce(
+			(sum: number, position: any) => sum + Number(position?.totalValue || 0),
+			0
+		);
+		const concentrationPct =
+			totalValue > 0 && targetPosition
+				? Number(((Number(targetPosition.totalValue || 0) / totalValue) * 100).toFixed(2))
+				: null;
+		const sellSimulation = input?.sellSimulation;
+		return this.computeScore({
+			symbol: targetSymbol,
+			assetType: (targetSnapshot?.assetType || targetPosition?.assetType || 'other') as any,
+			qualityMetrics: {
+				roe: targetSnapshot?.fundamentals?.returnOnEquity ?? null,
+				netMargin: targetSnapshot?.fundamentals?.netMargin ?? null,
+				dividendYield: targetSnapshot?.dividendYield ?? null,
+			},
+			riskMetrics: {
+				changePercent24h: targetSnapshot?.performance?.changePercent ?? null,
+				concentrationPct,
+			},
+			valuationMetrics: {
+				priceToEarnings: targetSnapshot?.fundamentals?.priceToEarnings ?? null,
+				priceToBook: targetSnapshot?.fundamentals?.priceToBook ?? null,
+			},
+			fiscalMetrics: {
+				estimatedTaxRateOnPnl: sellSimulation?.taxRateApplied ?? null,
+				estimatedTaxAbsolute: sellSimulation?.estimatedTax ?? null,
+				monthlyExemptionApplied: Boolean(sellSimulation?.monthlyExemptionApplied),
+				hasOwnedPosition: Boolean(targetPosition),
+			},
+			portfolioFitMetrics: {
+				fitClassification: 'unknown',
+				diversificationDeltaScore: null,
+			},
+		});
+	}
+
+	private computeQualityScore(input: TrackerrScoreInput) {
+		const reasonCodes: TrackerrScoreReasonCode[] = [];
+		const roe = input.qualityMetrics.roe;
+		const margin = input.qualityMetrics.netMargin;
+		const dy = input.qualityMetrics.dividendYield;
+		let score = 50;
+
+		if (roe !== null) {
+			if (roe >= 18) {
+				score += 25;
+				reasonCodes.push(this.reason('score_up_quality_roe_high', 'qualidade', 'up', 'ROE robusto sustentando qualidade.', 0.25));
+			} else if (roe < 8) {
+				score -= 20;
+				reasonCodes.push(this.reason('score_down_quality_roe_low', 'qualidade', 'down', 'ROE baixo reduz qualidade estrutural.', 0.25));
+			}
+		} else {
+			reasonCodes.push(this.reason('score_neutral_quality_roe_missing', 'qualidade', 'neutral', 'ROE indisponível.', 0));
+		}
+
+		if (margin !== null) {
+			if (margin >= 0.15) {
+				score += 15;
+				reasonCodes.push(this.reason('score_up_quality_margin_high', 'qualidade', 'up', 'Margem líquida saudável.', 0.15));
+			} else if (margin < 0.05) {
+				score -= 12;
+				reasonCodes.push(this.reason('score_down_quality_margin_low', 'qualidade', 'down', 'Margem comprimida.', 0.15));
+			}
+		}
+
+		if (dy !== null && dy >= 0.06) {
+			score += 5;
+			reasonCodes.push(this.reason('score_up_quality_dividend_support', 'qualidade', 'up', 'Dividend yield contribui para consistência.', 0.05));
+		}
+
+		return {
+			pillar: 'qualidade' as const,
+			weight: PILLAR_WEIGHTS.qualidade,
+			score: this.clampScore(score),
+			reasonCodes,
+		};
+	}
+
+	private computeRiskScore(input: TrackerrScoreInput) {
+		const reasonCodes: TrackerrScoreReasonCode[] = [];
+		let score = 65;
+		const change24h = input.riskMetrics.changePercent24h;
+		const concentration = input.riskMetrics.concentrationPct;
+
+		if (change24h !== null && Math.abs(change24h) >= 6) {
+			score -= 15;
+			reasonCodes.push(this.reason('score_down_risk_volatility_spike', 'risco', 'down', 'Volatilidade de curto prazo elevada.', 0.2));
+		}
+		if (concentration !== null) {
+			if (concentration >= 20) {
+				score -= 20;
+				reasonCodes.push(this.reason('score_down_risk_concentration_high', 'risco', 'down', 'Concentração elevada no ativo.', 0.2));
+			} else if (concentration <= 8) {
+				score += 8;
+				reasonCodes.push(this.reason('score_up_risk_concentration_balanced', 'risco', 'up', 'Peso equilibrado na carteira.', 0.1));
+			}
+		}
+
+		return {
+			pillar: 'risco' as const,
+			weight: PILLAR_WEIGHTS.risco,
+			score: this.clampScore(score),
+			reasonCodes,
+		};
+	}
+
+	private computeValuationScore(input: TrackerrScoreInput) {
+		const reasonCodes: TrackerrScoreReasonCode[] = [];
+		let score = 50;
+		const pe = input.valuationMetrics.priceToEarnings;
+		const pb = input.valuationMetrics.priceToBook;
+
+		if (pe !== null) {
+			if (pe > 22) {
+				score -= 18;
+				reasonCodes.push(this.reason('score_down_valuation_pe_expensive', 'valuation', 'down', 'P/L acima da faixa de conforto.', 0.2));
+			} else if (pe > 0 && pe <= 12) {
+				score += 18;
+				reasonCodes.push(this.reason('score_up_valuation_pe_attractive', 'valuation', 'up', 'P/L atrativo frente ao lucro.', 0.2));
+			}
+		}
+		if (pb !== null) {
+			if (pb > 3) {
+				score -= 10;
+				reasonCodes.push(this.reason('score_down_valuation_pb_stretched', 'valuation', 'down', 'P/VP esticado.', 0.1));
+			} else if (pb > 0 && pb <= 1.5) {
+				score += 10;
+				reasonCodes.push(this.reason('score_up_valuation_pb_reasonable', 'valuation', 'up', 'P/VP em faixa razoável.', 0.1));
+			}
+		}
+
+		return {
+			pillar: 'valuation' as const,
+			weight: PILLAR_WEIGHTS.valuation,
+			score: this.clampScore(score),
+			reasonCodes,
+		};
+	}
+
+	private computeFiscalScore(input: TrackerrScoreInput) {
+		const reasonCodes: TrackerrScoreReasonCode[] = [];
+		if (!input.fiscalMetrics.hasOwnedPosition) {
+			reasonCodes.push(this.reason('score_neutral_fiscal_no_owned_position', 'fiscal', 'neutral', 'Sem posição própria para simulação fiscal.', 0));
+			return {
+				pillar: 'fiscal' as const,
+				weight: PILLAR_WEIGHTS.fiscal,
+				score: 50,
+				reasonCodes,
+			};
+		}
+
+		let score = 55;
+		if (input.fiscalMetrics.monthlyExemptionApplied) {
+			score += 25;
+			reasonCodes.push(this.reason('score_up_fiscal_monthly_exemption', 'fiscal', 'up', 'Isenção mensal aplicável na simulação.', 0.15));
+		}
+		if ((input.fiscalMetrics.estimatedTaxAbsolute || 0) > 0) {
+			score -= 18;
+			reasonCodes.push(this.reason('score_down_fiscal_tax_due', 'fiscal', 'down', 'Venda gera DARF estimado positivo.', 0.15));
+		}
+
+		return {
+			pillar: 'fiscal' as const,
+			weight: PILLAR_WEIGHTS.fiscal,
+			score: this.clampScore(score),
+			reasonCodes,
+		};
+	}
+
+	private computePortfolioFitScore(input: TrackerrScoreInput) {
+		const reasonCodes: TrackerrScoreReasonCode[] = [];
+		let score = 50;
+		if (input.portfolioFitMetrics.fitClassification === 'bom') {
+			score = 80;
+			reasonCodes.push(this.reason('score_up_portfolio_fit_good', 'portfolio_fit', 'up', 'Ativo melhora encaixe da carteira.', 0.2));
+		} else if (input.portfolioFitMetrics.fitClassification === 'ruim') {
+			score = 30;
+			reasonCodes.push(this.reason('score_down_portfolio_fit_poor', 'portfolio_fit', 'down', 'Ativo piora perfil de carteira.', 0.2));
+		} else if (input.portfolioFitMetrics.fitClassification === 'unknown') {
+			reasonCodes.push(this.reason('score_neutral_portfolio_fit_unknown', 'portfolio_fit', 'neutral', 'Fit não pôde ser validado.', 0));
+		}
+
+		const delta = input.portfolioFitMetrics.diversificationDeltaScore;
+		if (typeof delta === 'number') {
+			if (delta >= 3) {
+				score += 8;
+				reasonCodes.push(this.reason('score_up_portfolio_fit_diversification', 'portfolio_fit', 'up', 'Diversificação melhora no cenário estimado.', 0.1));
+			} else if (delta <= -3) {
+				score -= 8;
+				reasonCodes.push(this.reason('score_down_portfolio_fit_diversification', 'portfolio_fit', 'down', 'Diversificação piora no cenário estimado.', 0.1));
+			}
+		}
+
+		return {
+			pillar: 'portfolio_fit' as const,
+			weight: PILLAR_WEIGHTS.portfolio_fit,
+			score: this.clampScore(score),
+			reasonCodes,
+		};
+	}
+
+	private buildScoreDirectionReasons(
+		input: TrackerrScoreInput,
+		pillars: Array<{ pillar: TrackerrScorePillar; score: number; reasonCodes: TrackerrScoreReasonCode[] }>
+	) {
+		if (input.previousPillarScores) {
+			const upward = pillars
+				.filter(
+					(pillar) =>
+						typeof input.previousPillarScores?.[pillar.pillar] === 'number' &&
+						pillar.score > Number(input.previousPillarScores[pillar.pillar])
+				)
+				.map((pillar) => `score_up_${pillar.pillar}_vs_previous`);
+			const downward = pillars
+				.filter(
+					(pillar) =>
+						typeof input.previousPillarScores?.[pillar.pillar] === 'number' &&
+						pillar.score < Number(input.previousPillarScores[pillar.pillar])
+				)
+				.map((pillar) => `score_down_${pillar.pillar}_vs_previous`);
+			return {
+				upward,
+				downward,
+			};
+		}
+
+		const allReasons = pillars.flatMap((pillar) => pillar.reasonCodes);
+		return {
+			upward: allReasons
+				.filter((reason) => reason.direction === 'up')
+				.map((reason) => reason.code),
+			downward: allReasons
+				.filter((reason) => reason.direction === 'down')
+				.map((reason) => reason.code),
+		};
+	}
+
+	private reason(
+		code: string,
+		pillar: TrackerrScorePillar,
+		direction: 'up' | 'down' | 'neutral',
+		description: string,
+		weightImpact: number
+	): TrackerrScoreReasonCode {
+		return {
+			code,
+			pillar,
+			direction,
+			description,
+			weightImpact,
+		};
+	}
+
+	private clampScore(value: number): number {
+		return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+	}
+}

--- a/src/intelligence/application/trackerr-score.types.ts
+++ b/src/intelligence/application/trackerr-score.types.ts
@@ -1,0 +1,73 @@
+import { TaxAssetType } from 'src/fiscal/tax-engine/domain/tax-engine.types';
+
+export type TrackerrScorePillar =
+	| 'qualidade'
+	| 'risco'
+	| 'valuation'
+	| 'fiscal'
+	| 'portfolio_fit';
+
+export interface TrackerrScoreReasonCode {
+	code: string;
+	pillar: TrackerrScorePillar;
+	direction: 'up' | 'down' | 'neutral';
+	description: string;
+	weightImpact: number;
+}
+
+export interface TrackerrScorePillarBreakdown {
+	pillar: TrackerrScorePillar;
+	weight: number;
+	score: number;
+	weightedScore: number;
+	reasonCodes: TrackerrScoreReasonCode[];
+}
+
+export interface TrackerrScoreOutput {
+	symbol: string;
+	assetType: TaxAssetType | 'other';
+	status: 'ok' | 'degraded';
+	overall: number;
+	overallScore: number;
+	weights: Record<TrackerrScorePillar, number>;
+	pillars: TrackerrScorePillarBreakdown[];
+	reasonCodes: {
+		upward: string[];
+		downward: string[];
+	};
+	warnings: string[];
+	explanation: {
+		summary: string;
+		topPositiveDrivers: string[];
+		topNegativeDrivers: string[];
+	};
+}
+
+export interface TrackerrScoreInput {
+	symbol: string;
+	assetType: TaxAssetType | 'other';
+	qualityMetrics: {
+		roe: number | null;
+		netMargin: number | null;
+		dividendYield: number | null;
+	};
+	riskMetrics: {
+		changePercent24h: number | null;
+		concentrationPct: number | null;
+	};
+	valuationMetrics: {
+		priceToEarnings: number | null;
+		priceToBook: number | null;
+	};
+	fiscalMetrics: {
+		estimatedTaxRateOnPnl: number | null;
+		estimatedTaxAbsolute: number | null;
+		monthlyExemptionApplied: boolean;
+		hasOwnedPosition: boolean;
+	};
+	portfolioFitMetrics: {
+		fitClassification: 'bom' | 'neutro' | 'ruim' | 'unknown';
+		diversificationDeltaScore: number | null;
+	};
+	previousPillarScores?: Partial<Record<TrackerrScorePillar, number>>;
+}

--- a/src/intelligence/application/trade-decision.service.spec.ts
+++ b/src/intelligence/application/trade-decision.service.spec.ts
@@ -1,0 +1,53 @@
+import { TradeDecisionService } from 'src/intelligence/application/trade-decision.service';
+import { TaxEngineService } from 'src/fiscal/tax-engine/application/tax-engine.service';
+
+describe('TradeDecisionService', () => {
+	const taxEngineServiceMock = {
+		simulateSaleImpact: jest.fn(),
+	} as unknown as TaxEngineService;
+
+	beforeEach(() => jest.clearAllMocks());
+
+	it('returns degraded output for invalid inputs', () => {
+		const service = new TradeDecisionService(taxEngineServiceMock);
+		const result = service.buildPreAndPostTrade({
+			symbol: 'PETR4',
+			assetType: 'stock',
+			quantityToSell: 0,
+			sellPrice: 0,
+			simulatedSellDate: new Date().toISOString(),
+			currentPosition: { quantity: 10, totalCost: 1000 },
+			totalPortfolioValue: 10000,
+		});
+		expect(result.status).toBe('degraded');
+		expect(result.warnings).toContain('trade_decision_invalid_inputs');
+	});
+
+	it('builds pre and post trade one-click output deterministically', () => {
+		(taxEngineServiceMock.simulateSaleImpact as jest.Mock).mockReturnValue({
+			estimatedTax: 150,
+			taxRateApplied: 0.15,
+			classification: 'tributavel',
+			monthlyExemptionApplied: false,
+			remainingQuantity: 5,
+			realizedPnl: 1000,
+			compensationUsed: 0,
+		});
+		const service = new TradeDecisionService(taxEngineServiceMock);
+		const result = service.buildPreAndPostTrade({
+			symbol: 'PETR4',
+			assetType: 'stock',
+			quantityToSell: 5,
+			sellPrice: 30,
+			simulatedSellDate: new Date().toISOString(),
+			currentPosition: { quantity: 10, totalCost: 200 },
+			totalPortfolioValue: 2000,
+		});
+
+		expect(result.status).toBe('ok');
+		expect(result.preTrade.estimatedTax).toBe(150);
+		expect(result.postTrade.estimatedDarf).toBe(150);
+		expect(result.preTrade.alternatives).toHaveLength(3);
+		expect(result.postTrade.portfolioImpactPercent).toBeLessThan(0);
+	});
+});

--- a/src/intelligence/application/trade-decision.service.ts
+++ b/src/intelligence/application/trade-decision.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@nestjs/common';
+import { TaxEngineService } from 'src/fiscal/tax-engine/application/tax-engine.service';
+import { TaxAssetType } from 'src/fiscal/tax-engine/domain/tax-engine.types';
+
+export interface TradeDecisionInput {
+	symbol: string;
+	assetType: TaxAssetType;
+	quantityToSell: number;
+	sellPrice: number;
+	simulatedSellDate: string;
+	currentPosition: {
+		quantity: number;
+		totalCost: number;
+	};
+	totalPortfolioValue: number;
+	accumulatedCompensableLoss?: number;
+	stockMonthlyGrossSales?: number;
+}
+
+export interface TradeDecisionOutput {
+	status: 'ok' | 'degraded';
+	preTrade: {
+		estimatedTax: number;
+		taxRateApplied: number;
+		classification: string;
+		alternatives: Array<{
+			id: 'sell_less' | 'compensate_loss' | 'suggested_order';
+			title: string;
+			description: string;
+		}>;
+		explanation: string;
+	};
+	postTrade: {
+		estimatedDarf: number;
+		remainingQuantity: number;
+		portfolioImpactPercent: number;
+		explanation: string;
+	};
+	warnings: string[];
+}
+
+@Injectable()
+export class TradeDecisionService {
+	constructor(private readonly taxEngineService: TaxEngineService) {}
+
+	buildPreAndPostTrade(input: TradeDecisionInput): TradeDecisionOutput {
+		const warnings: string[] = [];
+		if (input.quantityToSell <= 0 || input.sellPrice <= 0) {
+			return {
+				status: 'degraded',
+				preTrade: {
+					estimatedTax: 0,
+					taxRateApplied: 0,
+					classification: 'indisponivel',
+					alternatives: [],
+					explanation:
+						'Não foi possível simular pré-trade por falta de quantidade ou preço válidos.',
+				},
+				postTrade: {
+					estimatedDarf: 0,
+					remainingQuantity: Number(input.currentPosition?.quantity || 0),
+					portfolioImpactPercent: 0,
+					explanation:
+						'Não foi possível estimar impacto pós-trade com os dados informados.',
+				},
+				warnings: ['trade_decision_invalid_inputs'],
+			};
+		}
+
+		const sellImpact = this.taxEngineService.simulateSaleImpact({
+			symbol: input.symbol,
+			assetType: input.assetType,
+			quantityToSell: input.quantityToSell,
+			sellPrice: input.sellPrice,
+			simulatedSellDate: input.simulatedSellDate,
+			currentPosition: input.currentPosition,
+			accumulatedCompensableLoss: input.accumulatedCompensableLoss,
+			stockMonthlyGrossSales: input.stockMonthlyGrossSales,
+		});
+
+		const grossProceeds = Number(input.quantityToSell || 0) * Number(input.sellPrice || 0);
+		const portfolioImpactPercent =
+			input.totalPortfolioValue > 0
+				? Number((-(grossProceeds / input.totalPortfolioValue) * 100).toFixed(2))
+				: 0;
+		if (input.totalPortfolioValue <= 0) {
+			warnings.push('trade_decision_portfolio_value_unavailable');
+		}
+
+		const halfQuantity = Number((input.quantityToSell * 0.5).toFixed(8));
+		const alternatives: TradeDecisionOutput['preTrade']['alternatives'] = [
+			{
+				id: 'sell_less',
+				title: 'Vender menos agora',
+				description: `Simular venda parcial (${halfQuantity}) para reduzir DARF no curto prazo.`,
+			},
+			{
+				id: 'compensate_loss',
+				title: 'Compensar com prejuízo acumulado',
+				description:
+					sellImpact.compensationUsed > 0
+						? `Compensação estimada aplicada: R$ ${sellImpact.compensationUsed.toFixed(2)}.`
+						: 'Verificar prejuízos compensáveis para reduzir base tributável da operação.',
+			},
+			{
+				id: 'suggested_order',
+				title: 'Ordem sugerida de execução',
+				description:
+					sellImpact.estimatedTax > 0
+						? 'Executar venda parcial primeiro e reavaliar imposto antes de zerar posição.'
+						: 'Venda atual tende a manter impacto fiscal baixo com os dados disponíveis.',
+			},
+		];
+
+		const status: TradeDecisionOutput['status'] =
+			sellImpact.taxRateApplied > 0 || sellImpact.realizedPnl !== 0 ? 'ok' : 'degraded';
+		if (status === 'degraded') {
+			warnings.push('trade_decision_partial_estimation');
+		}
+
+		return {
+			status,
+			preTrade: {
+				estimatedTax: sellImpact.estimatedTax,
+				taxRateApplied: sellImpact.taxRateApplied,
+				classification: sellImpact.classification,
+				alternatives,
+				explanation:
+					sellImpact.monthlyExemptionApplied
+						? 'Pré-trade: a simulação indica isenção mensal aplicável para a venda atual.'
+						: 'Pré-trade: imposto estimado calculado com engine fiscal determinística.',
+			},
+			postTrade: {
+				estimatedDarf: sellImpact.estimatedTax,
+				remainingQuantity: sellImpact.remainingQuantity,
+				portfolioImpactPercent,
+				explanation:
+					sellImpact.remainingQuantity <= 0
+						? 'Pós-trade: posição será encerrada se a ordem for executada integralmente.'
+						: 'Pós-trade: posição permanece aberta após a venda simulada.',
+			},
+			warnings,
+		};
+	}
+}

--- a/src/intelligence/application/unified-intelligence.facade.spec.ts
+++ b/src/intelligence/application/unified-intelligence.facade.spec.ts
@@ -3,6 +3,7 @@ import { TaxEngineService } from 'src/fiscal/tax-engine/application/tax-engine.s
 import { FutureSimulatorService } from 'src/intelligence/application/future-simulator.service';
 import { OpportunityRadarService } from 'src/intelligence/application/opportunity-radar.service';
 import { PremiumInsightsService } from 'src/intelligence/application/premium-insights.service';
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
 import { UnifiedIntelligenceFacade } from 'src/intelligence/application/unified-intelligence.facade';
 import { PortfolioIntelligenceService } from 'src/portfolio/intelligence/application/portfolio-intelligence.service';
 
@@ -32,6 +33,10 @@ describe('UnifiedIntelligenceFacade', () => {
 		generate: jest.fn(),
 	} as unknown as PremiumInsightsService;
 
+	const mockTrackerrScoreService = {
+		build: jest.fn(),
+	} as unknown as TrackerrScoreService;
+
 	const makeFacade = () =>
 		new UnifiedIntelligenceFacade(
 			mockPortfolioIntelligenceService,
@@ -39,7 +44,8 @@ describe('UnifiedIntelligenceFacade', () => {
 			mockTaxEngineService,
 			mockOpportunityRadarService,
 			mockFutureSimulatorService,
-			mockPremiumInsightsService
+			mockPremiumInsightsService,
+			mockTrackerrScoreService
 		);
 
 	afterEach(() => jest.clearAllMocks());
@@ -295,6 +301,46 @@ describe('UnifiedIntelligenceFacade', () => {
 		expect(mockPremiumInsightsService.generate).toHaveBeenCalledWith({
 			plan: 'premium',
 			positions: [],
+		});
+	});
+
+	it('delegates trackerr score build', () => {
+		(mockTrackerrScoreService.build as jest.Mock).mockReturnValue({
+			symbol: 'ITUB4',
+			assetType: 'stock',
+			status: 'ok',
+			overall: 77,
+			overallScore: 77,
+			weights: {
+				qualidade: 0.25,
+				risco: 0.2,
+				valuation: 0.2,
+				fiscal: 0.15,
+				portfolio_fit: 0.2,
+			},
+			pillars: [],
+			reasonCodes: {
+				upward: [],
+				downward: [],
+			},
+			warnings: [],
+			explanation: {
+				summary: 'ok',
+				topPositiveDrivers: [],
+				topNegativeDrivers: [],
+			},
+		});
+
+		const facade = makeFacade();
+		const output = facade.getTrackerrScore({
+			positions: [],
+			targetSymbol: 'ITUB4',
+		});
+
+		expect(output.overallScore).toBe(77);
+		expect(mockTrackerrScoreService.build).toHaveBeenCalledWith({
+			positions: [],
+			targetSymbol: 'ITUB4',
 		});
 	});
 });

--- a/src/intelligence/application/unified-intelligence.facade.ts
+++ b/src/intelligence/application/unified-intelligence.facade.ts
@@ -4,6 +4,7 @@ import { TaxEngineService } from 'src/fiscal/tax-engine/application/tax-engine.s
 import { FutureSimulatorService } from 'src/intelligence/application/future-simulator.service';
 import { OpportunityRadarService } from 'src/intelligence/application/opportunity-radar.service';
 import { PremiumInsightsService } from 'src/intelligence/application/premium-insights.service';
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
 import { PortfolioIntelligenceService } from 'src/portfolio/intelligence/application/portfolio-intelligence.service';
 import {
 	FutureSimulatorInput,
@@ -21,6 +22,8 @@ import {
 	UnifiedPortfolioSummaryOutput,
 	UnifiedSellSimulationInput,
 	UnifiedSellSimulationOutput,
+	UnifiedTrackerrScoreInput,
+	UnifiedTrackerrScoreOutput,
 } from 'src/intelligence/application/unified-intelligence.types';
 
 @Injectable()
@@ -31,7 +34,8 @@ export class UnifiedIntelligenceFacade {
 		private readonly taxEngineService: TaxEngineService,
 		private readonly opportunityRadarService: OpportunityRadarService,
 		private readonly futureSimulatorService: FutureSimulatorService,
-		private readonly premiumInsightsService: PremiumInsightsService
+		private readonly premiumInsightsService: PremiumInsightsService,
+		private readonly trackerrScoreService: TrackerrScoreService
 	) {}
 
 	getPortfolioSummary(
@@ -107,5 +111,11 @@ export class UnifiedIntelligenceFacade {
 		input: PremiumInsightsInput
 	): Promise<PremiumInsightsOutput> {
 		return this.premiumInsightsService.generate(input);
+	}
+
+	getTrackerrScore(
+		input: UnifiedTrackerrScoreInput
+	): UnifiedTrackerrScoreOutput {
+		return this.trackerrScoreService.build(input);
 	}
 }

--- a/src/intelligence/application/unified-intelligence.types.ts
+++ b/src/intelligence/application/unified-intelligence.types.ts
@@ -4,6 +4,10 @@ import {
 	SellSimulationOutput,
 } from 'src/fiscal/tax-engine/domain/tax-engine.types';
 import {
+	TrackerrScoreInput,
+	TrackerrScoreOutput,
+} from 'src/intelligence/application/trackerr-score.types';
+import {
 	PortfolioFitAnalysisOutput,
 	PortfolioFitCandidateInput,
 	PortfolioIntelligenceOutput,
@@ -53,6 +57,19 @@ export type UnifiedCompareAssetsOutput = ComparisonEngineOutput;
 
 export type UnifiedSellSimulationInput = SellSimulationInput;
 export type UnifiedSellSimulationOutput = SellSimulationOutput;
+export type UnifiedTrackerrScoreInput =
+	| TrackerrScoreInput
+	| {
+			positions: PortfolioIntelligencePosition[];
+			targetSymbol?: string;
+			targetSnapshot?: unknown;
+			sellSimulation?: {
+				taxRateApplied?: number;
+				estimatedTax?: number;
+				monthlyExemptionApplied?: boolean;
+			};
+	  };
+export type UnifiedTrackerrScoreOutput = TrackerrScoreOutput;
 
 export type OpportunityRadarKind =
 	| 'risk'

--- a/src/intelligence/intelligence.module.ts
+++ b/src/intelligence/intelligence.module.ts
@@ -2,8 +2,12 @@ import { Module } from '@nestjs/common';
 import { ComparisonModule } from 'src/comparison/comparison.module';
 import { TaxEngineModule } from 'src/fiscal/tax-engine/tax-engine.module';
 import { FutureSimulatorService } from 'src/intelligence/application/future-simulator.service';
+import { InvestmentCommitteeBriefingService } from 'src/intelligence/application/investment-committee-briefing.service';
+import { InvestorProfileInsightsService } from 'src/intelligence/application/investor-profile-insights.service';
 import { OpportunityRadarService } from 'src/intelligence/application/opportunity-radar.service';
 import { PremiumInsightsService } from 'src/intelligence/application/premium-insights.service';
+import { TrackerrScoreService } from 'src/intelligence/application/trackerr-score.service';
+import { TradeDecisionService } from 'src/intelligence/application/trade-decision.service';
 import { UnifiedIntelligenceFacade } from 'src/intelligence/application/unified-intelligence.facade';
 import { MarketDataModule } from 'src/market-data/market-data.module';
 import { PortfolioModule } from 'src/portfolio/portfolio.module';
@@ -20,7 +24,17 @@ import { PortfolioModule } from 'src/portfolio/portfolio.module';
 		OpportunityRadarService,
 		FutureSimulatorService,
 		PremiumInsightsService,
+		TradeDecisionService,
+		TrackerrScoreService,
+		InvestorProfileInsightsService,
+		InvestmentCommitteeBriefingService,
 	],
-	exports: [UnifiedIntelligenceFacade],
+	exports: [
+		UnifiedIntelligenceFacade,
+		TradeDecisionService,
+		TrackerrScoreService,
+		InvestorProfileInsightsService,
+		InvestmentCommitteeBriefingService,
+	],
 })
 export class IntelligenceModule {}

--- a/src/ri-intelligence/application/ri-document-summary.service.spec.ts
+++ b/src/ri-intelligence/application/ri-document-summary.service.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, jest } from '@jest/globals';
 import { RiDocumentSummaryService } from 'src/ri-intelligence/application/ri-document-summary.service';
 import { RiSummaryCachePort } from 'src/ri-intelligence/application/ri-summary-cache.port';
 import { RiSummarySynthesizerPort } from 'src/ri-intelligence/application/ri-summary-synthesizer.port';
@@ -28,6 +29,7 @@ describe('RiDocumentSummaryService', () => {
 		O lucro líquido apresentou alta e a margem EBITDA teve expansão relevante.
 		A administração comentou guidance para o próximo ano e citou riscos macroeconômicos.
 		O endividamento teve redução com estratégia de desalavancagem.
+		O capex do período teve aumento para sustentar expansão operacional.
 	`.repeat(4);
 
 	it('returns ai summary successfully and stores cache', async () => {
@@ -55,6 +57,7 @@ describe('RiDocumentSummaryService', () => {
 			expect.arrayContaining(['Receita em alta'])
 		);
 		expect(output.structuredSignals.revenue.detected).toBe(true);
+		expect(output.structuredSignals.capex.detected).toBe(true);
 		expect(output.cost.aiCalls).toBe(1);
 		expect(cache.set).toHaveBeenCalled();
 	});
@@ -127,6 +130,7 @@ describe('RiDocumentSummaryService', () => {
 				profit: { detected: true, direction: 'up', evidence: [] },
 				margin: { detected: false, direction: 'unknown', evidence: [] },
 				indebtedness: { detected: false, direction: 'unknown', evidence: [] },
+				capex: { detected: false, direction: 'unknown', evidence: [] },
 				guidance: { detected: false, direction: 'unknown', evidence: [] },
 				risks: { detected: false, direction: 'unknown', evidence: [] },
 				toneShift: { detected: false, direction: 'unknown', evidence: [] },

--- a/src/ri-intelligence/application/ri-document-summary.service.ts
+++ b/src/ri-intelligence/application/ri-document-summary.service.ts
@@ -212,6 +212,12 @@ export class RiDocumentSummaryService {
 				['reducao', 'redução', 'queda', 'desalavancagem'],
 				['aumento', 'alta', 'piora']
 			),
+			capex: this.detectSignal(
+				text,
+				['capex', 'investimentos', 'investimento'],
+				['aumento', 'alta', 'expansao', 'expansão'],
+				['reducao', 'redução', 'queda', 'corte']
+			),
 			guidance: this.detectSignal(
 				text,
 				['guidance', 'projecao', 'projeção', 'perspectiva'],

--- a/src/ri-intelligence/application/ri-summary.types.ts
+++ b/src/ri-intelligence/application/ri-summary.types.ts
@@ -11,6 +11,7 @@ export interface RiStructuredSignals {
 	profit: RiStructuredSignalItem;
 	margin: RiStructuredSignalItem;
 	indebtedness: RiStructuredSignalItem;
+	capex: RiStructuredSignalItem;
 	guidance: RiStructuredSignalItem;
 	risks: RiStructuredSignalItem;
 	toneShift: RiStructuredSignalItem;

--- a/src/ri-intelligence/ri-intelligence.controller.spec.ts
+++ b/src/ri-intelligence/ri-intelligence.controller.spec.ts
@@ -101,7 +101,16 @@ describe('RiIntelligenceController', () => {
 				limitations: ['ri_content_insufficient_for_summary'],
 				sourceLabel: 'structured_fallback',
 			},
-			structuredSignals: {},
+			structuredSignals: {
+				revenue: { detected: false, direction: 'unknown', evidence: [] },
+				profit: { detected: false, direction: 'unknown', evidence: [] },
+				margin: { detected: false, direction: 'unknown', evidence: [] },
+				indebtedness: { detected: false, direction: 'unknown', evidence: [] },
+				capex: { detected: false, direction: 'unknown', evidence: [] },
+				guidance: { detected: false, direction: 'unknown', evidence: [] },
+				risks: { detected: false, direction: 'unknown', evidence: [] },
+				toneShift: { detected: false, direction: 'unknown', evidence: [] },
+			},
 			cache: {
 				key: null,
 				hit: false,


### PR DESCRIPTION
Introduce new services for generating investment committee briefings and profile-specific insights. Implement asset scoring calculations and enhance structured signals. Update unit tests and create new types to support these features.