### PR TITLE
feat(server): recognize colloquial and explicit @ticker mentions in chat

### DIFF
--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -5,6 +5,7 @@ import { IntelligenceModule } from 'src/intelligence/intelligence.module';
 import { MarketDataModule } from 'src/market-data/market-data.module';
 import { PortfolioModule } from 'src/portfolio/portfolio.module';
 import { RiIntelligenceModule } from 'src/ri-intelligence/ri-intelligence.module';
+import { StockModule } from 'src/stocks/stocks.module';
 import { AiController } from './ai.controller';
 import { IntelligentChatService } from './intelligence/intelligent-chat.service';
 import { CHAT_COST_OBSERVER } from './orchestration/chat-cost-observer.port';
@@ -22,6 +23,7 @@ import { AiService } from './ai.service';
 		ComparisonModule,
 		IntelligenceModule,
 		RiIntelligenceModule,
+		StockModule,
 	],
 	controllers: [AiController],
 	providers: [

--- a/src/ai/orchestration/chat-orchestrator.service.spec.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.spec.ts
@@ -6,6 +6,7 @@ import { MarketDataProviderPort } from 'src/market-data/application/market-data-
 import { PortfolioService } from 'src/portfolio/portfolio.service';
 import { RiDocumentSummaryService } from 'src/ri-intelligence/application/ri-document-summary.service';
 import { RiDocumentQueryPort } from 'src/ri-intelligence/application/ri-document-query.port';
+import { StockService } from 'src/stocks/stocks.service';
 
 describe('ChatOrchestratorService', () => {
 	const mockPortfolioService = {
@@ -46,6 +47,17 @@ describe('ChatOrchestratorService', () => {
 		getPreviousComparable: jest.fn(),
 	};
 
+	// Known-ticker universe covering every symbol referenced by question text
+	// across this suite, so the new known-ticker validation in extractSymbols
+	// doesn't silently drop symbols these pre-existing tests rely on.
+	const mockStockService = {
+		getAllNational: jest.fn().mockResolvedValue({
+			stocks: ['ITUB4', 'PETR4', 'BBAS3', 'BBDC4', 'ABCD3', 'XPLG11'].map(
+				(stock) => ({ stock, name: stock })
+			),
+		}),
+	} as unknown as StockService;
+
 	const makeService = () =>
 		new ChatOrchestratorService(
 			mockPortfolioService,
@@ -54,7 +66,8 @@ describe('ChatOrchestratorService', () => {
 			mockResponseCache,
 			mockCostObserver,
 			mockRiDocumentSummaryService,
-			mockRiDocumentQuery
+			mockRiDocumentQuery,
+			mockStockService
 		);
 
 	beforeEach(() => {
@@ -1425,5 +1438,62 @@ describe('ChatOrchestratorService', () => {
 		expect(
 			(response.data.tradePlaybook as any)?.preTrade?.alternatives?.length
 		).toBe(3);
+	});
+});
+
+describe('ChatOrchestratorService.extractSymbols', () => {
+	beforeEach(() => {
+		// The known-ticker cache is a static field shared across instances (and
+		// across the describe block above, which already populated it) — reset
+		// it so each test here observes only its own stub stock list.
+		(ChatOrchestratorService as any).knownTickersCache = null;
+	});
+
+	function buildServiceWithStubStockList(stockSymbols: string[]) {
+		const stockService = {
+			getAllNational: jest.fn().mockResolvedValue({
+				stocks: stockSymbols.map((stock) => ({ stock, name: stock })),
+			}),
+		} as unknown as StockService;
+
+		// Construct with minimal stub dependencies for the other constructor params —
+		// none of them are exercised by extractSymbols, so simple empty objects are fine.
+		const service = new (ChatOrchestratorService as any)(
+			{} /* portfolioService */,
+			{} /* unifiedIntelligenceFacade */,
+			{} /* marketDataProvider */,
+			{} /* responseCache */,
+			{} /* costObserver */,
+			{} /* riDocumentSummaryService */,
+			undefined /* riDocumentQuery */,
+			stockService
+		);
+		return service;
+	}
+
+	it('recognizes an exact 4-letter+digit ticker unchanged (regression)', async () => {
+		const service = buildServiceWithStubStockList(['PETR4', 'WEGE3']);
+		const result = await (service as any).extractSymbols('PETR4 é uma boa compra?');
+		expect(result).toEqual(['PETR4']);
+	});
+
+	it('resolves a colloquial 3-letter ticker to the real 4-letter ticker via prefix match', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3', 'PETR4']);
+		const result = await (service as any).extractSymbols('WEG3 é uma boa compra?');
+		expect(result).toEqual(['WEGE3']);
+	});
+
+	it('discards a 3-6 letter+digit candidate that matches no real ticker', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3', 'PETR4']);
+		const result = await (service as any).extractSymbols('ABC9 é uma boa compra?');
+		expect(result).toEqual([]);
+	});
+
+	it('caches the ticker list across calls within the TTL (single network call for two extractions)', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3']);
+		const stockService = (service as any).stockService as StockService;
+		await (service as any).extractSymbols('WEG3?');
+		await (service as any).extractSymbols('WEGE3?');
+		expect(stockService.getAllNational).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/ai/orchestration/chat-orchestrator.service.spec.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.spec.ts
@@ -66,8 +66,8 @@ describe('ChatOrchestratorService', () => {
 			mockResponseCache,
 			mockCostObserver,
 			mockRiDocumentSummaryService,
-			mockRiDocumentQuery,
-			mockStockService
+			mockStockService,
+			mockRiDocumentQuery
 		);
 
 	beforeEach(() => {
@@ -1447,6 +1447,7 @@ describe('ChatOrchestratorService.extractSymbols', () => {
 		// across the describe block above, which already populated it) — reset
 		// it so each test here observes only its own stub stock list.
 		(ChatOrchestratorService as any).knownTickersCache = null;
+		(ChatOrchestratorService as any).knownTickersNegativeCacheExpiresAt = null;
 	});
 
 	function buildServiceWithStubStockList(stockSymbols: string[]) {
@@ -1465,8 +1466,26 @@ describe('ChatOrchestratorService.extractSymbols', () => {
 			{} /* responseCache */,
 			{} /* costObserver */,
 			{} /* riDocumentSummaryService */,
-			undefined /* riDocumentQuery */,
-			stockService
+			stockService,
+			undefined /* riDocumentQuery */
+		);
+		return service;
+	}
+
+	function buildServiceWithFailingStockList() {
+		const stockService = {
+			getAllNational: jest.fn().mockRejectedValue(new Error('brapi unavailable')),
+		} as unknown as StockService;
+
+		const service = new (ChatOrchestratorService as any)(
+			{} /* portfolioService */,
+			{} /* unifiedIntelligenceFacade */,
+			{} /* marketDataProvider */,
+			{} /* responseCache */,
+			{} /* costObserver */,
+			{} /* riDocumentSummaryService */,
+			stockService,
+			undefined /* riDocumentQuery */
 		);
 		return service;
 	}
@@ -1495,5 +1514,88 @@ describe('ChatOrchestratorService.extractSymbols', () => {
 		await (service as any).extractSymbols('WEG3?');
 		await (service as any).extractSymbols('WEGE3?');
 		expect(stockService.getAllNational).toHaveBeenCalledTimes(1);
+	});
+
+	// Finding 1 (Critical): the real known-ticker source (StockService.getAllNational
+	// -> BrapiAdapter.listAllStocks, hardcoded type=stock) never returns FIIs or BDRs.
+	// A candidate matching the legacy strict 4-letter+digit shape must pass through
+	// unvalidated, exactly like before this branch, so these aren't silently dropped.
+	it('does not drop a FII ticker (4-letter shape) even though it is absent from the stocks-only known-ticker list', async () => {
+		const service = buildServiceWithStubStockList(['PETR4']); // no FIIs in the known list
+		const result = await (service as any).extractSymbols('Vale a pena comprar XPLG11?');
+		expect(result).toEqual(['XPLG11']);
+	});
+
+	it('does not drop a BDR ticker (4-letter shape) even though it is absent from the stocks-only known-ticker list', async () => {
+		const service = buildServiceWithStubStockList(['PETR4']); // no BDRs in the known list
+		const result = await (service as any).extractSymbols('O que acha de AAPL34?');
+		expect(result).toEqual(['AAPL34']);
+	});
+
+	// Finding 2 (Important): on a cold cache with a failed fetch, exact 4-letter
+	// tickers must still resolve — they no longer depend on the known-ticker set.
+	it('still recognizes an exact 4-letter ticker when the known-ticker fetch fails', async () => {
+		const service = buildServiceWithFailingStockList();
+		const result = await (service as any).extractSymbols('PETR4 é uma boa compra?');
+		expect(result).toEqual(['PETR4']);
+	});
+
+	// Finding 3 (Important): a fetch failure must be logged and negatively cached so
+	// an outage doesn't trigger a fresh failing HTTP call on every chat message.
+	it('logs a warning and negatively caches a fetch failure instead of retrying on every call', async () => {
+		const service = buildServiceWithFailingStockList();
+		const stockService = (service as any).stockService as StockService;
+		const warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined);
+
+		await (service as any).extractSymbols('PETR4?');
+		await (service as any).extractSymbols('PETR4?');
+
+		expect(warnSpy).toHaveBeenCalled();
+		expect(stockService.getAllNational).toHaveBeenCalledTimes(1);
+	});
+
+	// Finding 4 (Important): an ambiguous short prefix that matches more than one
+	// real known ticker with the same digit suffix must not be auto-resolved.
+	it('does not resolve an ambiguous prefix that matches multiple known tickers with the same digit suffix', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3', 'WEGA3']);
+		const result = await (service as any).extractSymbols('WEG3 é uma boa compra?');
+		expect(result).toEqual([]);
+	});
+
+	it('still resolves a prefix that unambiguously matches exactly one known ticker', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3', 'PETR4']);
+		const result = await (service as any).extractSymbols('WEG3 é uma boa compra?');
+		expect(result).toEqual(['WEGE3']);
+	});
+
+	// Finding 5 (Important): server-side coverage for the @TICKER explicit-mention
+	// path, the branch's headline feature.
+	it('recognizes an @TICKER explicit mention', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3']);
+		const result = await (service as any).extractSymbols('O que acha de @WEGE3?');
+		expect(result).toEqual(['WEGE3']);
+	});
+
+	it('accepts an unknown/fake ticker via the @ explicit-mention bypass (deliberate design, not an oversight)', async () => {
+		const service = buildServiceWithStubStockList(['WEGE3']);
+		const result = await (service as any).extractSymbols('O que acha de @FAKE9?');
+		expect(result).toEqual(['FAKE9']);
+	});
+
+	it('gives explicit @ mentions priority over text-derived candidates in the top-6 truncation', async () => {
+		const service = buildServiceWithStubStockList([
+			'PETR4',
+			'VALE3',
+			'ITUB4',
+			'BBAS3',
+			'BBDC4',
+			'ABEV3',
+			'WEGE3',
+		]);
+		const result = await (service as any).extractSymbols(
+			'@WEGE3 comparado com PETR4 VALE3 ITUB4 BBAS3 BBDC4 ABEV3'
+		);
+		expect(result).toHaveLength(6);
+		expect(result[0]).toBe('WEGE3');
 	});
 });

--- a/src/ai/orchestration/chat-orchestrator.service.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.ts
@@ -27,6 +27,7 @@ import {
 	RiDocumentQueryPort,
 } from 'src/ri-intelligence/application/ri-document-query.port';
 import { RiDocumentSummaryOutput } from 'src/ri-intelligence/application/ri-summary.types';
+import { StockService } from 'src/stocks/stocks.service';
 
 @Injectable()
 export class ChatOrchestratorService {
@@ -42,7 +43,8 @@ export class ChatOrchestratorService {
 		private readonly riDocumentSummaryService: RiDocumentSummaryService,
 		@Optional()
 		@Inject(RI_DOCUMENT_QUERY)
-		private readonly riDocumentQuery?: RiDocumentQueryPort
+		private readonly riDocumentQuery?: RiDocumentQueryPort,
+		private readonly stockService?: StockService
 	) {}
 
 	async orchestrate(
@@ -77,7 +79,7 @@ export class ChatOrchestratorService {
 			this.mapDecisionFlowToCopilot(options?.decisionFlow || null);
 		const symbols = options?.decisionFlow?.ticker
 			? [this.normalizeTicker(options.decisionFlow.ticker)]
-			: this.extractSymbols(normalizedQuestion);
+			: await this.extractSymbols(normalizedQuestion);
 		const investorProfile = this.resolveInvestorProfile(
 			options?.investorProfile || null,
 			normalizedQuestion
@@ -1889,22 +1891,85 @@ export class ChatOrchestratorService {
 		return Number.isFinite(inferred) && inferred > 0 ? inferred : 0;
 	}
 
-	private extractSymbols(question: string): string[] {
-		const normalized = question.toUpperCase();
-		const brSymbols = normalized.match(/\b[A-Z]{4}\d{1,2}\b/g) || [];
-		const cryptoSymbols = normalized.match(/\b(BTC|ETH|SOL|ADA|XRP)\b/g) || [];
-		const usSymbols = normalized.match(/\b[A-Z]{1,5}\.[A-Z]{1,3}\b/g) || [];
+	private static knownTickersCache: { expiresAt: number; tickers: Set<string> } | null = null;
+	private static readonly KNOWN_TICKERS_TTL_MS = 24 * 60 * 60 * 1000;
 
-		const candidateSymbols = [
-			...brSymbols,
-			...cryptoSymbols,
-			...usSymbols,
-		].filter((symbol) => symbol.length >= 3 && !this.stopWords.has(symbol));
-		return Array.from(
-			new Set(candidateSymbols.map((symbol) => this.normalizeTicker(symbol)))
-		)
+	private async getKnownTickers(): Promise<Set<string>> {
+		const now = Date.now();
+		if (
+			ChatOrchestratorService.knownTickersCache &&
+			ChatOrchestratorService.knownTickersCache.expiresAt > now
+		) {
+			return ChatOrchestratorService.knownTickersCache.tickers;
+		}
+		if (!this.stockService) return new Set();
+		try {
+			const response = await this.stockService.getAllNational('', 1000, 1, 'name');
+			const tickers = new Set<string>(
+				(response?.stocks || [])
+					.map((entry: any) => String(entry?.stock || '').toUpperCase())
+					.filter(Boolean)
+			);
+			ChatOrchestratorService.knownTickersCache = {
+				expiresAt: now + ChatOrchestratorService.KNOWN_TICKERS_TTL_MS,
+				tickers,
+			};
+			return tickers;
+		} catch {
+			return ChatOrchestratorService.knownTickersCache?.tickers || new Set();
+		}
+	}
+
+	private resolveKnownTicker(candidate: string, knownTickers: Set<string>): string | null {
+		if (knownTickers.has(candidate)) return candidate;
+
+		const match = candidate.match(/^([A-Z]+)(\d{1,2})$/);
+		if (!match) return null;
+		const [, alphaPrefix, digits] = match;
+
+		for (const known of knownTickers) {
+			const knownMatch = known.match(/^([A-Z]+)(\d{1,2})$/);
+			if (!knownMatch) continue;
+			const [, knownAlpha, knownDigits] = knownMatch;
+			if (knownDigits === digits && knownAlpha.startsWith(alphaPrefix)) {
+				return known;
+			}
+		}
+		return null;
+	}
+
+	private async extractSymbols(question: string): Promise<string[]> {
+		const normalized = question.toUpperCase();
+		const explicitMentions: string[] =
+			normalized.match(/@([A-Z]{3,6}\d{1,2})\b/g) || [];
+		const explicitTickers = explicitMentions.map((mention) => mention.slice(1));
+
+		const brSymbols: string[] = normalized.match(/\b[A-Z]{3,6}\d{1,2}\b/g) || [];
+		const cryptoSymbols: string[] =
+			normalized.match(/\b(BTC|ETH|SOL|ADA|XRP)\b/g) || [];
+		const usSymbols: string[] = normalized.match(/\b[A-Z]{1,5}\.[A-Z]{1,3}\b/g) || [];
+
+		const candidateSymbols = [...brSymbols, ...cryptoSymbols, ...usSymbols].filter(
+			(symbol) => symbol.length >= 3 && !this.stopWords.has(symbol)
+		);
+
+		const knownTickers = await this.getKnownTickers();
+		const resolvedFromText = candidateSymbols
+			.map((symbol) => this.normalizeTicker(symbol))
 			.filter(Boolean)
-			.slice(0, 6);
+			.map((symbol) => {
+				// Crypto/US symbols aren't in the B3 known-ticker list — pass them through unresolved.
+				if (cryptoSymbols.includes(symbol) || usSymbols.includes(symbol)) return symbol;
+				return this.resolveKnownTicker(symbol, knownTickers);
+			})
+			.filter((symbol): symbol is string => !!symbol);
+
+		const allSymbols = [
+			...explicitTickers.map((symbol) => this.normalizeTicker(symbol)),
+			...resolvedFromText,
+		];
+
+		return Array.from(new Set(allSymbols)).filter(Boolean).slice(0, 6);
 	}
 
 	private parseSellInputs(question: string): {

--- a/src/ai/orchestration/chat-orchestrator.service.ts
+++ b/src/ai/orchestration/chat-orchestrator.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { createHash } from 'crypto';
 import {
 	CHAT_COST_OBSERVER,
@@ -31,6 +31,8 @@ import { StockService } from 'src/stocks/stocks.service';
 
 @Injectable()
 export class ChatOrchestratorService {
+	private readonly logger = new Logger(ChatOrchestratorService.name);
+
 	constructor(
 		private readonly portfolioService: PortfolioService,
 		private readonly unifiedIntelligenceFacade: UnifiedIntelligenceFacade,
@@ -41,10 +43,10 @@ export class ChatOrchestratorService {
 		@Inject(CHAT_COST_OBSERVER)
 		private readonly costObserver: ChatCostObserverPort,
 		private readonly riDocumentSummaryService: RiDocumentSummaryService,
+		private readonly stockService: StockService,
 		@Optional()
 		@Inject(RI_DOCUMENT_QUERY)
-		private readonly riDocumentQuery?: RiDocumentQueryPort,
-		private readonly stockService?: StockService
+		private readonly riDocumentQuery?: RiDocumentQueryPort
 	) {}
 
 	async orchestrate(
@@ -1891,18 +1893,55 @@ export class ChatOrchestratorService {
 		return Number.isFinite(inferred) && inferred > 0 ? inferred : 0;
 	}
 
-	private static knownTickersCache: { expiresAt: number; tickers: Set<string> } | null = null;
+	private static knownTickersCache: {
+		expiresAt: number;
+		tickers: Set<string>;
+		byDigitSuffix: Map<string, Array<{ alpha: string; full: string }>>;
+	} | null = null;
+	// Distinct from "never fetched": set only after a failed fetch, so a
+	// provider outage is retried after a short cooldown instead of on every
+	// single chat message (or never, if we kept the stale empty cache forever).
+	private static knownTickersNegativeCacheExpiresAt: number | null = null;
 	private static readonly KNOWN_TICKERS_TTL_MS = 24 * 60 * 60 * 1000;
+	private static readonly KNOWN_TICKERS_NEGATIVE_TTL_MS = 5 * 60 * 1000;
 
-	private async getKnownTickers(): Promise<Set<string>> {
+	private static buildDigitSuffixIndex(
+		tickers: Set<string>
+	): Map<string, Array<{ alpha: string; full: string }>> {
+		const index = new Map<string, Array<{ alpha: string; full: string }>>();
+		for (const known of tickers) {
+			const knownMatch = known.match(/^([A-Z]+)(\d{1,2})$/);
+			if (!knownMatch) continue;
+			const [, knownAlpha, knownDigits] = knownMatch;
+			const bucket = index.get(knownDigits) || [];
+			bucket.push({ alpha: knownAlpha, full: known });
+			index.set(knownDigits, bucket);
+		}
+		return index;
+	}
+
+	private async getKnownTickers(): Promise<{
+		tickers: Set<string>;
+		byDigitSuffix: Map<string, Array<{ alpha: string; full: string }>>;
+	}> {
 		const now = Date.now();
 		if (
 			ChatOrchestratorService.knownTickersCache &&
 			ChatOrchestratorService.knownTickersCache.expiresAt > now
 		) {
-			return ChatOrchestratorService.knownTickersCache.tickers;
+			return ChatOrchestratorService.knownTickersCache;
 		}
-		if (!this.stockService) return new Set();
+		if (
+			ChatOrchestratorService.knownTickersNegativeCacheExpiresAt &&
+			ChatOrchestratorService.knownTickersNegativeCacheExpiresAt > now
+		) {
+			return (
+				ChatOrchestratorService.knownTickersCache || {
+					tickers: new Set(),
+					byDigitSuffix: new Map(),
+				}
+			);
+		}
 		try {
 			const response = await this.stockService.getAllNational('', 1000, 1, 'name');
 			const tickers = new Set<string>(
@@ -1910,32 +1949,48 @@ export class ChatOrchestratorService {
 					.map((entry: any) => String(entry?.stock || '').toUpperCase())
 					.filter(Boolean)
 			);
+			const byDigitSuffix = ChatOrchestratorService.buildDigitSuffixIndex(tickers);
 			ChatOrchestratorService.knownTickersCache = {
 				expiresAt: now + ChatOrchestratorService.KNOWN_TICKERS_TTL_MS,
 				tickers,
+				byDigitSuffix,
 			};
-			return tickers;
-		} catch {
-			return ChatOrchestratorService.knownTickersCache?.tickers || new Set();
+			ChatOrchestratorService.knownTickersNegativeCacheExpiresAt = null;
+			return ChatOrchestratorService.knownTickersCache;
+		} catch (error) {
+			this.logger.warn(
+				`Failed to fetch known B3 tickers for chat ticker validation: ${error instanceof Error ? error.message : String(error)}`
+			);
+			ChatOrchestratorService.knownTickersNegativeCacheExpiresAt =
+				now + ChatOrchestratorService.KNOWN_TICKERS_NEGATIVE_TTL_MS;
+			return (
+				ChatOrchestratorService.knownTickersCache || {
+					tickers: new Set(),
+					byDigitSuffix: new Map(),
+				}
+			);
 		}
 	}
 
-	private resolveKnownTicker(candidate: string, knownTickers: Set<string>): string | null {
-		if (knownTickers.has(candidate)) return candidate;
+	private resolveKnownTicker(
+		candidate: string,
+		knownTickers: {
+			tickers: Set<string>;
+			byDigitSuffix: Map<string, Array<{ alpha: string; full: string }>>;
+		}
+	): string | null {
+		if (knownTickers.tickers.has(candidate)) return candidate;
 
 		const match = candidate.match(/^([A-Z]+)(\d{1,2})$/);
 		if (!match) return null;
 		const [, alphaPrefix, digits] = match;
 
-		for (const known of knownTickers) {
-			const knownMatch = known.match(/^([A-Z]+)(\d{1,2})$/);
-			if (!knownMatch) continue;
-			const [, knownAlpha, knownDigits] = knownMatch;
-			if (knownDigits === digits && knownAlpha.startsWith(alphaPrefix)) {
-				return known;
-			}
-		}
-		return null;
+		const bucket = knownTickers.byDigitSuffix.get(digits) || [];
+		const matches = bucket.filter((item) => item.alpha.startsWith(alphaPrefix));
+		// Ambiguous prefix (multiple real tickers share this short prefix + digit
+		// suffix): don't guess which one the user meant — treat as unresolved.
+		if (matches.length !== 1) return null;
+		return matches[0].full;
 	}
 
 	private async extractSymbols(question: string): Promise<string[]> {
@@ -1960,6 +2015,13 @@ export class ChatOrchestratorService {
 			.map((symbol) => {
 				// Crypto/US symbols aren't in the B3 known-ticker list — pass them through unresolved.
 				if (cryptoSymbols.includes(symbol) || usSymbols.includes(symbol)) return symbol;
+				// Legacy shape (exactly 4 letters + 1-2 digits): this is what the old,
+				// pre-widening regex accepted with NO validation. Known-ticker
+				// validation only gates the newly-introduced 3/5/6-letter matching
+				// space; gating this legacy shape too would silently drop FIIs/BDRs
+				// (e.g. XPLG11, AAPL34) that the stocks-only known-ticker source
+				// (StockService.getAllNational -> type=stock) never returns.
+				if (/^[A-Z]{4}\d{1,2}$/.test(symbol)) return symbol;
 				return this.resolveKnownTicker(symbol, knownTickers);
 			})
 			.filter((symbol): symbol is string => !!symbol);


### PR DESCRIPTION
## Summary
- Widens `ChatOrchestratorService.extractSymbols()` from requiring exactly 4 letters before digits to 3-6 letters, so colloquial mentions like "WEG3" resolve to the real ticker "WEGE3", validated against a cached (24h TTL) B3 ticker list to avoid false positives.
- Adds `@TICKER` explicit-mention recognition with top priority, bypassing validation — pairs with the `web` repo's `feature/chat-ticker-mention-input` PR, which lets users insert these via an autocomplete dropdown.
- The final whole-branch review caught that the known-ticker validation, sourced only from `type=stock`, would have silently dropped FIIs (e.g. MXRF11) and BDRs (e.g. AAPL34) that worked fine under the old regex — fixed by letting any candidate matching the legacy exact 4-letter shape bypass validation entirely, so only the newly-widened 3/5/6-letter space is gated.
- Also hardened: negative caching + logging on a market-data outage (previously silent, and would have disabled ALL non-`@` ticker recognition including exact matches), and ambiguous prefix resolution now requires exactly one match (previously picked an arbitrary one non-deterministically).

## Test plan
- [x] 420/423 passing — the 3 failures are pre-existing and unrelated (`ai/ai.controller.spec.ts` mocks `ChatOrchestratorService` wholesale; `resilient-ri-document-discovery.adapter.spec.ts` is untouched by this diff).
- [x] New tests: colloquial resolution, FII/BDR regression guard, `@TICKER` explicit mentions (including deliberately-unknown `@FAKE9`), outage degradation, ambiguous-match rejection.
- [ ] Manual: ask the chat "WEG3 é uma boa compra?" and confirm it resolves to WEGE3's real data; ask about a FII by its plain ticker (e.g. "MXRF11") and confirm it's still recognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)