### PR TITLE
fix(server): fix RI Inteligente document discovery for companies outside the top 5

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -17,6 +17,8 @@ const envSchema = z.object({
 	ASAAS_API_KEY: z.string(),
 	ASAAS_URL_SANDBOX: z.string(),
 	GOOGLE_CLIENT_ID: z.string().optional(),
+	GOOGLE_CSE_API_KEY: z.string().optional(),
+	GOOGLE_CSE_ENGINE_ID: z.string().optional(),
 });
 
 const isTestEnvironment = process.env.NODE_ENV === 'test';
@@ -64,3 +66,6 @@ export const port: string = env.data.PORT;
 export const asaasApiKey: string = env.data.ASAAS_API_KEY;
 export const asaasUrlSandbox: string = env.data.ASAAS_URL_SANDBOX;
 export const googleClientId: string | undefined = env.data.GOOGLE_CLIENT_ID;
+export const googleCseApiKey: string | undefined = env.data.GOOGLE_CSE_API_KEY;
+export const googleCseEngineId: string | undefined =
+	env.data.GOOGLE_CSE_ENGINE_ID;

--- a/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
@@ -9,6 +9,7 @@ import {
 	ResolveRiDocumentLinkResult,
 } from 'src/ri-intelligence/application/ri-document-link-resolver.port';
 import { RiDocumentRecord } from 'src/ri-intelligence/domain/ri-document.types';
+import { RiOriginSearchPort } from 'src/ri-intelligence/application/ri-origin-search.port';
 
 describe('RiDocumentCatalogService', () => {
 	const baseDocument = (
@@ -65,13 +66,17 @@ describe('RiDocumentCatalogService', () => {
 			resolve:
 				params?.resolve || jest.fn().mockResolvedValue(validResolution()),
 		};
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 
 		const service = new RiDocumentCatalogService(
 			autocomplete,
 			discovery,
-			resolver
+			resolver,
+			originSearch
 		);
-		return { service, autocomplete, discovery, resolver };
+		return { service, autocomplete, discovery, resolver, originSearch };
 	}
 
 	it('1) returns a valid resolved document when link validation succeeds', async () => {
@@ -383,10 +388,14 @@ describe('RiDocumentCatalogService', () => {
 		const resolver: RiDocumentLinkResolverPort = {
 			resolve: jest.fn().mockResolvedValue(validResolution()),
 		};
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 		const service = new RiDocumentCatalogService(
 			autocomplete,
 			discovery,
-			resolver
+			resolver,
+			originSearch
 		);
 
 		const output = await service.search({ query: 'ITUB4' });
@@ -544,10 +553,14 @@ describe('RiDocumentCatalogService', () => {
 		const resolver: RiDocumentLinkResolverPort = {
 			resolve: jest.fn().mockResolvedValue(validResolution()),
 		};
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 		const service = new RiDocumentCatalogService(
 			autocomplete,
 			discovery,
-			resolver
+			resolver,
+			originSearch
 		);
 
 		await service.search({
@@ -587,10 +600,14 @@ describe('RiDocumentCatalogService', () => {
 		const resolver: RiDocumentLinkResolverPort = {
 			resolve: jest.fn().mockResolvedValue(validResolution()),
 		};
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 		const service = new RiDocumentCatalogService(
 			autocomplete,
 			discovery,
-			resolver
+			resolver,
+			originSearch
 		);
 
 		const output = await service.search({
@@ -630,10 +647,14 @@ describe('RiDocumentCatalogService', () => {
 		const resolver: RiDocumentLinkResolverPort = {
 			resolve: jest.fn().mockResolvedValue(validResolution()),
 		};
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 		const service = new RiDocumentCatalogService(
 			autocomplete,
 			discovery,
-			resolver
+			resolver,
+			originSearch
 		);
 
 		const output = await service.search({
@@ -644,5 +665,81 @@ describe('RiDocumentCatalogService', () => {
 
 		expect(output.documents).toHaveLength(1);
 		expect(output.documents[0].id).toBe(within.id);
+	});
+});
+
+describe('RiDocumentCatalogService — origin resolution', () => {
+	it('uses the Google CSE fallback origin for a company outside the known list, instead of guessing a slug', async () => {
+		const originSearch = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue('https://ri.empresa-real.com.br'),
+		};
+		const documentDiscovery = {
+			discover: jest.fn().mockResolvedValue([]),
+		};
+		const assetAutocomplete = {
+			search: jest.fn().mockResolvedValue([
+				{ ticker: 'ABCD3', company: 'Empresa Real S.A.' },
+			]),
+		};
+		const linkResolver = { resolve: jest.fn() };
+
+		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+			assetAutocomplete,
+			documentDiscovery,
+			linkResolver,
+			originSearch
+		);
+
+		await service.search({ query: 'ABCD3', limit: 10 });
+
+		expect(originSearch.searchOfficialOrigin).toHaveBeenCalledWith('Empresa Real S.A.');
+		expect(documentDiscovery.discover).toHaveBeenCalledWith(
+			expect.objectContaining({ origin: 'https://ri.empresa-real.com.br' })
+		);
+	});
+
+	it('does not call Google CSE for a known ticker (uses the hardcoded origin)', async () => {
+		const originSearch = { searchOfficialOrigin: jest.fn() };
+		const documentDiscovery = { discover: jest.fn().mockResolvedValue([]) };
+		const assetAutocomplete = {
+			search: jest.fn().mockResolvedValue([{ ticker: 'PETR4', company: 'Petrobras' }]),
+		};
+		const linkResolver = { resolve: jest.fn() };
+
+		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+			assetAutocomplete,
+			documentDiscovery,
+			linkResolver,
+			originSearch
+		);
+
+		await service.search({ query: 'PETR4', limit: 10 });
+
+		expect(originSearch.searchOfficialOrigin).not.toHaveBeenCalled();
+		expect(documentDiscovery.discover).toHaveBeenCalledWith(
+			expect.objectContaining({ origin: 'https://petrobras.com.br/ri' })
+		);
+	});
+
+	it('passes a null origin (not a guessed slug URL) when Google CSE also finds nothing', async () => {
+		const originSearch = { searchOfficialOrigin: jest.fn().mockResolvedValue(null) };
+		const documentDiscovery = { discover: jest.fn().mockResolvedValue([]) };
+		const assetAutocomplete = {
+			search: jest.fn().mockResolvedValue([{ ticker: 'XYZW4', company: 'Empresa Obscura' }]),
+		};
+		const linkResolver = { resolve: jest.fn() };
+
+		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+			assetAutocomplete,
+			documentDiscovery,
+			linkResolver,
+			originSearch
+		);
+
+		await service.search({ query: 'XYZW4', limit: 10 });
+
+		expect(documentDiscovery.discover).toHaveBeenCalledWith(
+			expect.objectContaining({ origin: null })
+		);
 	});
 });

--- a/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
@@ -123,23 +123,23 @@ describe('RiDocumentCatalogService', () => {
 	});
 
 	it('resolves known RI origins for BBDC4 and PETR4 before link validation', async () => {
+		// Query genérica (sem match exato de ticker) para que resolveMatches
+		// retorne ambos os tickers e cada um seja descoberto/validado com a sua
+		// própria origem — replica o fan-out real por ticker (não por documento).
 		const resolve = jest
 			.fn()
 			.mockResolvedValue(
 				validResolution('https://ri.example.com/doc-valid.pdf')
 			);
-
-		const { service, resolver } = makeService({
-			matches: [
-				{ ticker: 'BBDC4', company: 'Banco Bradesco S.A.' },
-				{ ticker: 'PETR4', company: 'Petróleo Brasileiro S.A. - Petrobras' },
-			],
-			documents: [
+		const documentsByTicker: Record<string, RiDocumentRecord[]> = {
+			BBDC4: [
 				baseDocument({
 					ticker: 'BBDC4',
 					company: 'Banco Bradesco S.A.',
 					source: { type: 'url', value: '/docs/resultado-4t25.pdf' },
 				}),
+			],
+			PETR4: [
 				baseDocument({
 					id: 'PETR4:earnings_release:2026-02-26T00:00:00.000Z:0',
 					ticker: 'PETR4',
@@ -147,10 +147,33 @@ describe('RiDocumentCatalogService', () => {
 					source: { type: 'url', value: '/ri/release-resultados-4t25.pdf' },
 				}),
 			],
-			resolve,
-		});
+		};
 
-		await service.search({ query: 'PETR4' });
+		const autocomplete: RiAssetAutocompletePort = {
+			search: jest.fn().mockResolvedValue([
+				{ ticker: 'BBDC4', company: 'Banco Bradesco S.A.' },
+				{ ticker: 'PETR4', company: 'Petróleo Brasileiro S.A. - Petrobras' },
+			]),
+		};
+		const discovery: RiDocumentDiscoveryPort = {
+			discover: jest
+				.fn()
+				.mockImplementation(
+					async ({ ticker }) => documentsByTicker[ticker] || []
+				),
+		};
+		const resolver: RiDocumentLinkResolverPort = { resolve };
+		const originSearch: RiOriginSearchPort = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
+		const service = new RiDocumentCatalogService(
+			autocomplete,
+			discovery,
+			resolver,
+			originSearch
+		);
+
+		await service.search({ query: 'bancos e petroleo' });
 
 		const calls = (resolver.resolve as jest.Mock).mock.calls.map(
 			(call) => call[0]
@@ -741,5 +764,83 @@ describe('RiDocumentCatalogService — origin resolution', () => {
 		expect(documentDiscovery.discover).toHaveBeenCalledWith(
 			expect.objectContaining({ origin: null })
 		);
+	});
+
+	it('resolves the origin only once for a ticker even when multiple documents are validated (no fan-out per document)', async () => {
+		const originSearch = {
+			searchOfficialOrigin: jest
+				.fn()
+				.mockResolvedValue('https://ri.empresa-real.com.br'),
+		};
+		const documents = [
+			{
+				id: 'ABCD3:earnings_release:2026-02-06T00:00:00.000Z:0',
+				ticker: 'ABCD3',
+				company: 'Empresa Real S.A.',
+				title: 'Release de Resultados 4T25',
+				documentType: 'earnings_release',
+				period: '4T25',
+				publishedAt: '2026-02-06T00:00:00.000Z',
+				source: { type: 'url', value: 'https://ri.empresa-real.com.br/1.pdf' },
+				classification: { method: 'deterministic_rules', confidence: 'high' },
+				contentStatus: 'metadata_only',
+			},
+			{
+				id: 'ABCD3:material_fact:2026-02-10T00:00:00.000Z:0',
+				ticker: 'ABCD3',
+				company: 'Empresa Real S.A.',
+				title: 'Fato Relevante',
+				documentType: 'material_fact',
+				period: null,
+				publishedAt: '2026-02-10T00:00:00.000Z',
+				source: { type: 'url', value: 'https://ri.empresa-real.com.br/2.pdf' },
+				classification: { method: 'deterministic_rules', confidence: 'high' },
+				contentStatus: 'metadata_only',
+			},
+			{
+				id: 'ABCD3:investor_presentation:2026-02-12T00:00:00.000Z:0',
+				ticker: 'ABCD3',
+				company: 'Empresa Real S.A.',
+				title: 'Apresentação',
+				documentType: 'investor_presentation',
+				period: null,
+				publishedAt: '2026-02-12T00:00:00.000Z',
+				source: { type: 'url', value: 'https://ri.empresa-real.com.br/3.pdf' },
+				classification: { method: 'deterministic_rules', confidence: 'high' },
+				contentStatus: 'metadata_only',
+			},
+		];
+		const documentDiscovery = {
+			discover: jest.fn().mockResolvedValue(documents),
+		};
+		const assetAutocomplete = {
+			search: jest
+				.fn()
+				.mockResolvedValue([{ ticker: 'ABCD3', company: 'Empresa Real S.A.' }]),
+		};
+		const linkResolver = {
+			resolve: jest.fn().mockResolvedValue({
+				isValid: true,
+				resolvedUrl: 'https://ri.empresa-real.com.br/resolved.pdf',
+				statusCode: 200,
+				contentType: 'application/pdf',
+			}),
+		};
+
+		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+			assetAutocomplete,
+			documentDiscovery,
+			linkResolver,
+			originSearch
+		);
+
+		const output = await service.search({ query: 'ABCD3', limit: 10 });
+
+		expect(output.documents).toHaveLength(3);
+		// Regressão: sem o fix, resolveAndValidateDocument re-resolvia a origem
+		// para CADA documento, gerando 1 chamada de CSE por documento (fan-out).
+		// Com o fix, a origem é resolvida uma única vez por ticker e reutilizada.
+		expect(originSearch.searchOfficialOrigin).toHaveBeenCalledTimes(1);
+		expect(linkResolver.resolve).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/ri-intelligence/application/ri-document-catalog.service.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.ts
@@ -167,9 +167,11 @@ export class RiDocumentCatalogService {
 			};
 		}
 
+		const originByTicker = new Map<string, string | null>();
 		const gathered = await Promise.all(
 			matches.map(async (match) => {
 				const origin = await this.resolveOrigin(match);
+				originByTicker.set(match.ticker.toUpperCase(), origin);
 				const documents = await this.documentDiscovery.discover({
 					ticker: match.ticker,
 					company: match.company,
@@ -196,7 +198,12 @@ export class RiDocumentCatalogService {
 
 		const validated = (
 			await Promise.all(
-				scoped.map((document) => this.resolveAndValidateDocument(document))
+				scoped.map((document) =>
+					this.resolveAndValidateDocument(
+						document,
+						originByTicker.get(document.ticker.toUpperCase()) ?? null
+					)
+				)
 			)
 		).filter((document): document is RiDocumentRecord => Boolean(document));
 
@@ -319,7 +326,9 @@ export class RiDocumentCatalogService {
 
 		const validated = (
 			await Promise.all(
-				withinRange.map((document) => this.resolveAndValidateDocument(document))
+				withinRange.map((document) =>
+					this.resolveAndValidateDocument(document, officialRiUrl)
+				)
 			)
 		).filter((document): document is RiDocumentRecord => Boolean(document));
 		if (!validated.length) {
@@ -610,14 +619,11 @@ export class RiDocumentCatalogService {
 	}
 
 	private async resolveAndValidateDocument(
-		document: RiDocumentRecord
+		document: RiDocumentRecord,
+		origin: string | null
 	): Promise<RiDocumentRecord | null> {
 		if (document.source?.type !== 'url') return document;
 
-		const origin = await this.resolveOrigin({
-			ticker: document.ticker,
-			company: document.company,
-		});
 		const resolved = await this.documentLinkResolver.resolve({
 			url: document.source.value,
 			origin: origin || undefined,

--- a/src/ri-intelligence/application/ri-document-catalog.service.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.ts
@@ -13,6 +13,10 @@ import {
 	RiDocumentLinkResolverPort,
 } from 'src/ri-intelligence/application/ri-document-link-resolver.port';
 import {
+	RI_ORIGIN_SEARCH,
+	RiOriginSearchPort,
+} from 'src/ri-intelligence/application/ri-origin-search.port';
+import {
 	RiDocumentRecord,
 	RiDocumentType,
 } from 'src/ri-intelligence/domain/ri-document.types';
@@ -128,7 +132,9 @@ export class RiDocumentCatalogService {
 		@Inject(RI_DOCUMENT_DISCOVERY)
 		private readonly documentDiscovery: RiDocumentDiscoveryPort,
 		@Inject(RI_DOCUMENT_LINK_RESOLVER)
-		private readonly documentLinkResolver: RiDocumentLinkResolverPort
+		private readonly documentLinkResolver: RiDocumentLinkResolverPort,
+		@Inject(RI_ORIGIN_SEARCH)
+		private readonly originSearch: RiOriginSearchPort
 	) {}
 
 	async autocomplete(query: string, limit = 8): Promise<RiAssetSuggestion[]> {
@@ -163,7 +169,7 @@ export class RiDocumentCatalogService {
 
 		const gathered = await Promise.all(
 			matches.map(async (match) => {
-				const origin = this.resolveOrigin(match);
+				const origin = await this.resolveOrigin(match);
 				const documents = await this.documentDiscovery.discover({
 					ticker: match.ticker,
 					company: match.company,
@@ -429,7 +435,7 @@ export class RiDocumentCatalogService {
 		}
 	}
 
-	private resolveOrigin(match: RiAssetSuggestion): string {
+	private async resolveOrigin(match: RiAssetSuggestion): Promise<string | null> {
 		const knownOrigins: Record<string, string> = {
 			BBDC4: 'https://ri.bradesco.com.br',
 			ITUB4: 'https://www.itau.com.br/relacoes-com-investidores',
@@ -445,16 +451,11 @@ export class RiDocumentCatalogService {
 			return `https://statusinvest.com.br/fii/${ticker.toLowerCase()}`;
 		}
 
-		const companySlug = String(match.company || '')
-			.toLowerCase()
-			.normalize('NFD')
-			.replace(/[\u0300-\u036f]/g, '')
-			.replace(/[^a-z0-9]+/g, '-')
-			.replace(/(^-|-$)/g, '')
-			.slice(0, 40);
-		return companySlug
-			? `https://ri.${companySlug}.com.br`
-			: 'https://ri.empresa.com.br';
+		try {
+			return await this.originSearch.searchOfficialOrigin(match.company);
+		} catch (error) {
+			return null;
+		}
 	}
 
 	private selectMostRelevantDocument(
@@ -613,12 +614,13 @@ export class RiDocumentCatalogService {
 	): Promise<RiDocumentRecord | null> {
 		if (document.source?.type !== 'url') return document;
 
+		const origin = await this.resolveOrigin({
+			ticker: document.ticker,
+			company: document.company,
+		});
 		const resolved = await this.documentLinkResolver.resolve({
 			url: document.source.value,
-			origin: this.resolveOrigin({
-				ticker: document.ticker,
-				company: document.company,
-			}),
+			origin: origin || undefined,
 		});
 		if (!resolved.isValid || !resolved.resolvedUrl) return null;
 

--- a/src/ri-intelligence/application/ri-document-discovery.port.ts
+++ b/src/ri-intelligence/application/ri-document-discovery.port.ts
@@ -5,7 +5,7 @@ export const RI_DOCUMENT_DISCOVERY = Symbol('RI_DOCUMENT_DISCOVERY');
 export interface RiDocumentDiscoveryInput {
 	ticker: string;
 	company: string;
-	origin: string;
+	origin: string | null;
 	/**
 	 * Filtro opcional de janela temporal (ISO date). Quando ausente, o adapter
 	 * usa seu default interno (ex.: últimos N dias). Aditivo: undefined preserva

--- a/src/ri-intelligence/application/ri-origin-search.port.ts
+++ b/src/ri-intelligence/application/ri-origin-search.port.ts
@@ -1,0 +1,5 @@
+export const RI_ORIGIN_SEARCH = Symbol('RI_ORIGIN_SEARCH');
+
+export interface RiOriginSearchPort {
+	searchOfficialOrigin(companyName: string): Promise<string | null>;
+}

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
@@ -45,9 +45,51 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 		expect(result).toBeNull();
 	});
 
-	it('returns null and does not throw when the request fails', async () => {
+	it('propagates the error when the request fails and no registry was ever loaded successfully', async () => {
+		// Importante: isso é diferente de "ticker não encontrado". Se o
+		// carregamento do registro falhar completamente (rede fora, etc.) e
+		// nunca tivermos tido um snapshot bem-sucedido, resolveCnpj precisa
+		// rejeitar (em vez de resolver com null) para que o chamador
+		// (StocksRiIssuerCatalogAdapter) não confunda essa falha transitória
+		// com "ticker genuinamente ausente do registro B3" e não poluir o
+		// cache negativo de 6h com uma falha de rede.
 		const adapter = buildAdapter(() => throwError(() => new Error('network down')));
-		await expect(adapter.resolveCnpj('ABCD3')).resolves.toBeNull();
+		await expect(adapter.resolveCnpj('ABCD3')).rejects.toThrow('network down');
+	});
+
+	it('serves the last successfully loaded registry when a later refresh fails (stale-but-known data beats an error)', async () => {
+		const getMock = jest
+			.fn()
+			.mockReturnValueOnce(
+				of(
+					singlePageResponse([
+						{
+							codeCVM: '9512',
+							issuingCompany: 'ABCD',
+							companyName: 'Empresa Real S.A.',
+							cnpj: '3987364000103',
+						},
+					])
+				)
+			)
+			.mockReturnValue(throwError(() => new Error('network down')));
+		const adapter = buildAdapter(getMock);
+
+		const first = await adapter.resolveCnpj('ABCD3');
+		expect(first).toEqual({
+			cnpj: '03987364000103',
+			company: 'Empresa Real S.A.',
+		});
+
+		// Força a expiração do cache interno para simular um refresh
+		// necessário que falha.
+		(adapter as any).cache = { ...(adapter as any).cache, expiresAt: 0 };
+
+		const second = await adapter.resolveCnpj('ABCD3');
+		expect(second).toEqual({
+			cnpj: '03987364000103',
+			company: 'Empresa Real S.A.',
+		});
 	});
 
 	it('caches the full registry across calls (single network call for two lookups)', async () => {

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
@@ -1,0 +1,129 @@
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { B3RegistryCnpjResolverAdapter } from './b3-registry-cnpj-resolver.adapter';
+
+// Formato confirmado ao vivo em 2026-08-10 contra
+// https://sistemaswebb3-listados.b3.com.br/listedCompaniesProxy/CompanyCall/GetInitialCompanies/<base64>
+// `issuingCompany` é o código-base do emissor (sem o dígito de espécie do
+// ticker) e `cnpj` vem sem zeros à esquerda.
+function singlePageResponse(rows: any[]) {
+	return {
+		data: {
+			page: { pageNumber: 1, pageSize: 120, totalRecords: rows.length, totalPages: 1 },
+			results: rows,
+		},
+	};
+}
+
+describe('B3RegistryCnpjResolverAdapter', () => {
+	function buildAdapter(getImpl: () => any) {
+		const httpService = { get: jest.fn(getImpl) } as unknown as HttpService;
+		return new B3RegistryCnpjResolverAdapter(httpService);
+	}
+
+	it('resolves a CNPJ for a ticker present in the B3 registry response', async () => {
+		const adapter = buildAdapter(() =>
+			of(
+				singlePageResponse([
+					{
+						codeCVM: '9512',
+						issuingCompany: 'ABCD',
+						companyName: 'Empresa Real S.A.',
+						tradingName: 'EMPRESA REAL',
+						cnpj: '3987364000103',
+					},
+				])
+			)
+		);
+		const result = await adapter.resolveCnpj('ABCD3');
+		expect(result).toEqual({ cnpj: '03987364000103', company: 'Empresa Real S.A.' });
+	});
+
+	it('returns null when the ticker is not found in the registry', async () => {
+		const adapter = buildAdapter(() => of(singlePageResponse([])));
+		const result = await adapter.resolveCnpj('ZZZZ9');
+		expect(result).toBeNull();
+	});
+
+	it('returns null and does not throw when the request fails', async () => {
+		const adapter = buildAdapter(() => throwError(() => new Error('network down')));
+		await expect(adapter.resolveCnpj('ABCD3')).resolves.toBeNull();
+	});
+
+	it('caches the full registry across calls (single network call for two lookups)', async () => {
+		const getMock = jest.fn(() =>
+			of(
+				singlePageResponse([
+					{
+						codeCVM: '1',
+						issuingCompany: 'AAAA',
+						companyName: 'X',
+						cnpj: '11111111000111',
+					},
+				])
+			)
+		);
+		const adapter = buildAdapter(getMock);
+		await adapter.resolveCnpj('AAAA3');
+		await adapter.resolveCnpj('AAAA3');
+		expect(getMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('matches the ticker by stripping the trailing security-class digit(s)', async () => {
+		const adapter = buildAdapter(() =>
+			of(
+				singlePageResponse([
+					{
+						codeCVM: '9512',
+						issuingCompany: 'PETR',
+						companyName: 'PETROLEO BRASILEIRO S.A. PETROBRAS',
+						cnpj: '33000167000101',
+					},
+				])
+			)
+		);
+		expect(await adapter.resolveCnpj('petr4')).toEqual({
+			cnpj: '33000167000101',
+			company: 'PETROLEO BRASILEIRO S.A. PETROBRAS',
+		});
+	});
+
+	it('fetches subsequent pages when the registry spans more than one page', async () => {
+		const page1 = {
+			data: {
+				page: { pageNumber: 1, pageSize: 120, totalRecords: 2, totalPages: 2 },
+				results: [
+					{ codeCVM: '1', issuingCompany: 'AAAA', companyName: 'A Co', cnpj: '11111111000111' },
+				],
+			},
+		};
+		const page2 = {
+			data: {
+				page: { pageNumber: 2, pageSize: 120, totalRecords: 2, totalPages: 2 },
+				results: [
+					{ codeCVM: '2', issuingCompany: 'BBBB', companyName: 'B Co', cnpj: '22222222000122' },
+				],
+			},
+		};
+		const getMock = jest.fn().mockReturnValueOnce(of(page1)).mockReturnValueOnce(of(page2));
+		const adapter = buildAdapter(getMock);
+
+		const result = await adapter.resolveCnpj('BBBB3');
+
+		expect(getMock).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({ cnpj: '22222222000122', company: 'B Co' });
+	});
+
+	it('skips rows missing a usable cnpj or company name', async () => {
+		const adapter = buildAdapter(() =>
+			of(
+				singlePageResponse([
+					{ codeCVM: '1', issuingCompany: 'CCCC', companyName: 'C Co', cnpj: '0' },
+					{ codeCVM: '2', issuingCompany: 'DDDD', companyName: '', cnpj: '33333333000133' },
+				])
+			)
+		);
+		expect(await adapter.resolveCnpj('CCCC3')).toBeNull();
+		expect(await adapter.resolveCnpj('DDDD3')).toBeNull();
+	});
+});

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
@@ -123,7 +123,15 @@ export class B3RegistryCnpjResolverAdapter {
 				this.logger.warn(
 					`Falha ao carregar registro B3 de companhias: ${error?.message || error}`
 				);
-				return this.cache?.byTicker || new Map();
+				// Se já existe um registro carregado com sucesso anteriormente
+				// (mesmo expirado), preferimos servi-lo a falhar — é dado real,
+				// só potencialmente desatualizado. Só propagamos o erro quando
+				// NUNCA houve um carregamento bem-sucedido, para que o chamador
+				// (StocksRiIssuerCatalogAdapter) possa distinguir "não encontrado
+				// num registro carregado" de "registro indisponível agora" e
+				// evitar poluir o cache negativo de 6h com uma falha transitória.
+				if (this.cache?.byTicker) return this.cache.byTicker;
+				throw error;
 			} finally {
 				this.inflight = null;
 			}

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
@@ -1,0 +1,160 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+
+interface RegistryEntry {
+	cnpj: string;
+	company: string;
+}
+
+interface B3CompanyRow {
+	issuingCompany?: string;
+	companyName?: string;
+	cnpj?: string;
+}
+
+interface B3GetInitialCompaniesResponse {
+	page?: {
+		pageNumber?: number;
+		pageSize?: number;
+		totalRecords?: number | null;
+		totalPages?: number | null;
+	};
+	results?: B3CompanyRow[];
+}
+
+/**
+ * Segunda fonte de CNPJ, usada como fallback quando a cotação da Brapi
+ * (`StocksRiIssuerCatalogAdapter`) não traz o campo `cnpj`.
+ *
+ * Consulta o endpoint público (sem API key) usado pela própria página
+ * "Empresas Listadas" da B3:
+ *
+ *   GET https://sistemaswebb3-listados.b3.com.br/listedCompaniesProxy/CompanyCall/GetInitialCompanies/<base64({language,pageNumber,pageSize})>
+ *
+ * Verificado ao vivo em 2026-08-10: retorna
+ * `{ page: { pageNumber, pageSize, totalRecords, totalPages }, results: [{ codeCVM, issuingCompany, companyName, tradingName, cnpj, ... }] }`.
+ * `pageSize` acima de ~120 é rejeitado silenciosamente pelo servidor
+ * (responde 200 com `results: []` e `page.totalRecords: null`), então
+ * paginamos em blocos de 120.
+ *
+ * Importante: `issuingCompany` é o código-base do emissor (ex.: "PETR"),
+ * SEM o dígito de espécie do ticker (ex.: "PETR4" tem espécie "4"). Por
+ * isso o matching de ticker → registro é feito removendo os dígitos finais
+ * do ticker. Além disso, o `cnpj` retornado pela B3 vem sem zeros à
+ * esquerda (ex.: "3987364000103" em vez de "03987364000103"), então
+ * normalizamos preenchendo até 14 dígitos.
+ */
+@Injectable()
+export class B3RegistryCnpjResolverAdapter {
+	private readonly logger = new Logger(B3RegistryCnpjResolverAdapter.name);
+	private readonly registryBaseUrl =
+		'https://sistemaswebb3-listados.b3.com.br/listedCompaniesProxy/CompanyCall/GetInitialCompanies';
+	private readonly pageSize = 120;
+	// Limite de segurança para não entrar em loop indefinido caso a API
+	// retorne um totalPages absurdo; hoje (2026-08-10) a B3 lista ~3500
+	// companhias, ou seja, ~30 páginas de 120.
+	private readonly maxPages = 60;
+
+	private cache: { expiresAt: number; byTicker: Map<string, RegistryEntry> } | null =
+		null;
+	private inflight: Promise<Map<string, RegistryEntry>> | null = null;
+	private readonly ttlMs = 24 * 60 * 60 * 1000;
+
+	constructor(private readonly httpService: HttpService) {}
+
+	private normalizeCnpj(cnpj?: string): string {
+		const digits = String(cnpj || '').replace(/[^\d]/g, '');
+		// A B3 usa "0" como placeholder de CNPJ para instrumentos sem CNPJ
+		// próprio (ex.: alguns ETPs/BDRs de cripto) — não é um CNPJ real.
+		if (!digits || /^0+$/.test(digits)) return '';
+		return digits.padStart(14, '0');
+	}
+
+	/** Remove o(s) dígito(s) de espécie no final do ticker (ex.: PETR4 → PETR). */
+	private baseCode(ticker: string): string {
+		return String(ticker || '')
+			.trim()
+			.toUpperCase()
+			.replace(/\d+$/, '');
+	}
+
+	private buildPageUrl(pageNumber: number): string {
+		const params = { language: 'pt-br', pageNumber, pageSize: this.pageSize };
+		const encoded = Buffer.from(JSON.stringify(params)).toString('base64');
+		return `${this.registryBaseUrl}/${encoded}`;
+	}
+
+	private async fetchPage(
+		pageNumber: number
+	): Promise<B3GetInitialCompaniesResponse> {
+		const response = await firstValueFrom(
+			this.httpService.get<B3GetInitialCompaniesResponse>(
+				this.buildPageUrl(pageNumber),
+				{ timeout: 15000 }
+			)
+		);
+		return response.data;
+	}
+
+	private async loadRegistry(): Promise<Map<string, RegistryEntry>> {
+		const now = Date.now();
+		if (this.cache && this.cache.expiresAt > now) return this.cache.byTicker;
+		if (this.inflight) return this.inflight;
+
+		this.inflight = (async () => {
+			try {
+				const byBaseCode = new Map<string, RegistryEntry>();
+				const first = await this.fetchPage(1);
+				this.mergeRows(byBaseCode, first.results);
+
+				const totalPages = Math.min(
+					first.page?.totalPages || 1,
+					this.maxPages
+				);
+				for (let page = 2; page <= totalPages; page++) {
+					const next = await this.fetchPage(page);
+					this.mergeRows(byBaseCode, next.results);
+				}
+
+				this.cache = { expiresAt: Date.now() + this.ttlMs, byTicker: byBaseCode };
+				return byBaseCode;
+			} catch (error) {
+				this.logger.warn(
+					`Falha ao carregar registro B3 de companhias: ${error?.message || error}`
+				);
+				return this.cache?.byTicker || new Map();
+			} finally {
+				this.inflight = null;
+			}
+		})();
+
+		return this.inflight;
+	}
+
+	private mergeRows(
+		target: Map<string, RegistryEntry>,
+		rows?: B3CompanyRow[]
+	): void {
+		for (const row of rows || []) {
+			const baseCode = String(row?.issuingCompany || '')
+				.trim()
+				.toUpperCase();
+			const cnpj = this.normalizeCnpj(row?.cnpj);
+			const company = String(row?.companyName || '').trim();
+			if (!baseCode || !cnpj || !company) continue;
+			target.set(baseCode, { cnpj, company });
+		}
+	}
+
+	async resolveCnpj(
+		ticker: string
+	): Promise<{ cnpj: string; company: string } | null> {
+		const normalizedTicker = String(ticker || '').trim().toUpperCase();
+		if (!normalizedTicker) return null;
+		const registry = await this.loadRegistry();
+		const entry = registry.get(this.baseCode(normalizedTicker));
+		if (!entry) return null;
+		return { cnpj: entry.cnpj, company: entry.company };
+	}
+}

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
@@ -38,4 +38,44 @@ describe('GoogleCseRiOriginSearchAdapter', () => {
 		expect(result).toBeNull();
 		expect(httpService.get).not.toHaveBeenCalled();
 	});
+
+	it('returns null instead of the URL when the top result is a known financial aggregator (statusinvest)', async () => {
+		const adapter = buildAdapter(() =>
+			of({
+				data: {
+					items: [
+						{
+							link: 'https://statusinvest.com.br/acoes/empresa-real',
+						},
+					],
+				},
+			})
+		);
+		const result = await adapter.searchOfficialOrigin('Empresa Real S.A.');
+		expect(result).toBeNull();
+	});
+
+	it('returns null when the top result is on a subdomain of a denylisted aggregator', async () => {
+		const adapter = buildAdapter(() =>
+			of({
+				data: {
+					items: [{ link: 'https://einvestidor.estadao.com.br/empresa-real' }],
+				},
+			})
+		);
+		const result = await adapter.searchOfficialOrigin('Empresa Real S.A.');
+		expect(result).toBeNull();
+	});
+
+	it('still resolves normally when the top result is the issuer own domain (regression check)', async () => {
+		const adapter = buildAdapter(() =>
+			of({
+				data: {
+					items: [{ link: 'https://ri.empresa-real.com.br/resultados' }],
+				},
+			})
+		);
+		const result = await adapter.searchOfficialOrigin('Empresa Real S.A.');
+		expect(result).toBe('https://ri.empresa-real.com.br');
+	});
 });

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
@@ -1,0 +1,41 @@
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { GoogleCseRiOriginSearchAdapter } from './google-cse-ri-origin-search.adapter';
+
+describe('GoogleCseRiOriginSearchAdapter', () => {
+	function buildAdapter(getImpl: () => any, apiKey = 'key', engineId = 'engine') {
+		const httpService = { get: jest.fn(getImpl) } as unknown as HttpService;
+		return new GoogleCseRiOriginSearchAdapter(httpService, apiKey, engineId);
+	}
+
+	it('returns the first result domain when Google CSE finds a match', async () => {
+		const adapter = buildAdapter(() =>
+			of({
+				data: {
+					items: [{ link: 'https://ri.empresa-real.com.br/resultados' }],
+				},
+			})
+		);
+		const result = await adapter.searchOfficialOrigin('Empresa Real S.A.');
+		expect(result).toBe('https://ri.empresa-real.com.br');
+	});
+
+	it('returns null when Google CSE returns no items', async () => {
+		const adapter = buildAdapter(() => of({ data: {} }));
+		const result = await adapter.searchOfficialOrigin('Empresa Sem RI S.A.');
+		expect(result).toBeNull();
+	});
+
+	it('returns null and does not throw when the request fails', async () => {
+		const adapter = buildAdapter(() => throwError(() => new Error('quota exceeded')));
+		await expect(adapter.searchOfficialOrigin('Empresa X')).resolves.toBeNull();
+	});
+
+	it('returns null immediately without a request when credentials are missing', async () => {
+		const httpService = { get: jest.fn() } as unknown as HttpService;
+		const adapter = new GoogleCseRiOriginSearchAdapter(httpService, undefined, undefined);
+		const result = await adapter.searchOfficialOrigin('Empresa Y');
+		expect(result).toBeNull();
+		expect(httpService.get).not.toHaveBeenCalled();
+	});
+});

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
@@ -1,0 +1,63 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+import { RiOriginSearchPort } from 'src/ri-intelligence/application/ri-origin-search.port';
+import { googleCseApiKey, googleCseEngineId } from 'src/env';
+
+@Injectable()
+export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
+	private readonly logger = new Logger(GoogleCseRiOriginSearchAdapter.name);
+	private readonly cache = new Map<string, { expiresAt: number; origin: string | null }>();
+	private readonly ttlMs = 24 * 60 * 60 * 1000;
+
+	constructor(
+		private readonly httpService: HttpService,
+		@Optional() private readonly apiKey: string | undefined = googleCseApiKey,
+		@Optional() private readonly engineId: string | undefined = googleCseEngineId
+	) {}
+
+	async searchOfficialOrigin(companyName: string): Promise<string | null> {
+		if (!this.apiKey || !this.engineId) {
+			this.logger.warn(
+				'GOOGLE_CSE_API_KEY/GOOGLE_CSE_ENGINE_ID não configurados; pulando busca de origem RI'
+			);
+			return null;
+		}
+
+		const normalizedName = String(companyName || '').trim();
+		if (!normalizedName) return null;
+
+		const now = Date.now();
+		const cached = this.cache.get(normalizedName);
+		if (cached && cached.expiresAt > now) return cached.origin;
+
+		try {
+			const query = `${normalizedName} relações com investidores site:.com.br`;
+			const response = await firstValueFrom(
+				this.httpService.get('https://www.googleapis.com/customsearch/v1', {
+					params: {
+						key: this.apiKey,
+						cx: this.engineId,
+						q: query,
+						num: 1,
+					},
+					timeout: 8000,
+				})
+			);
+			const firstLink: string | undefined = response.data?.items?.[0]?.link;
+			if (!firstLink) {
+				this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin: null });
+				return null;
+			}
+			const url = new URL(firstLink);
+			const origin = `${url.protocol}//${url.host}`;
+			this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin });
+			return origin;
+		} catch (error) {
+			this.logger.warn(
+				`Falha na busca Google CSE para "${normalizedName}": ${error?.message || error}`
+			);
+			return null;
+		}
+	}
+}

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
@@ -4,11 +4,51 @@ import { firstValueFrom } from 'rxjs';
 import { RiOriginSearchPort } from 'src/ri-intelligence/application/ri-origin-search.port';
 import { googleCseApiKey, googleCseEngineId } from 'src/env';
 
+/**
+ * Hosts de agregadores/portais financeiros conhecidos por aparecerem como
+ * resultado orgânico top para buscas de "{empresa} relações com
+ * investidores" sem serem o domínio oficial do emissor. Tratar o top-1 como
+ * "não encontrado" quando cair aqui é mais seguro do que rastrear o site
+ * errado e apresentar conteúdo de terceiros como documento oficial do
+ * emissor — nesse caso a descoberta degrada para CVM-only.
+ */
+const DENYLISTED_ORIGIN_HOSTS: ReadonlySet<string> = new Set([
+	'statusinvest.com.br',
+	'infomoney.com.br',
+	'fundamentei.com',
+	'investing.com',
+	'b3.com.br',
+	'money.cnn.com',
+	'google.com',
+	'investidor10.com.br',
+	'suno.com.br',
+	'oceans14.com.br',
+	'guiainvest.com.br',
+	'meusdividendos.com',
+	'tradingview.com',
+	'einvestidor.estadao.com.br',
+	'valor.globo.com',
+	'exame.com',
+	'bloomberg.com',
+	'reuters.com',
+	'wikipedia.org',
+	'linkedin.com',
+	'youtube.com',
+]);
+
 @Injectable()
 export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 	private readonly logger = new Logger(GoogleCseRiOriginSearchAdapter.name);
 	private readonly cache = new Map<string, { expiresAt: number; origin: string | null }>();
 	private readonly ttlMs = 24 * 60 * 60 * 1000;
+
+	private isDenylistedHost(hostname: string): boolean {
+		const normalized = hostname.toLowerCase();
+		for (const denied of DENYLISTED_ORIGIN_HOSTS) {
+			if (normalized === denied || normalized.endsWith(`.${denied}`)) return true;
+		}
+		return false;
+	}
 
 	constructor(
 		private readonly httpService: HttpService,
@@ -50,6 +90,13 @@ export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 				return null;
 			}
 			const url = new URL(firstLink);
+			if (this.isDenylistedHost(url.hostname)) {
+				this.logger.debug(
+					`Top resultado do CSE para "${normalizedName}" é um agregador conhecido (${url.hostname}); tratando como não encontrado`
+				);
+				this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin: null });
+				return null;
+			}
 			const origin = `${url.protocol}//${url.host}`;
 			this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin });
 			return origin;

--- a/src/ri-intelligence/infrastructure/http-ri-document-discovery.adapter.ts
+++ b/src/ri-intelligence/infrastructure/http-ri-document-discovery.adapter.ts
@@ -316,7 +316,7 @@ export class HttpRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryPort {
 		return Array.from(targets);
 	}
 
-	private normalizeOrigin(origin: string): string | null {
+	private normalizeOrigin(origin: string | null): string | null {
 		try {
 			const parsed = new URL(String(origin || '').trim());
 			if (!['http:', 'https:'].includes(parsed.protocol)) return null;

--- a/src/ri-intelligence/infrastructure/puppeteer-ri-document-discovery.adapter.ts
+++ b/src/ri-intelligence/infrastructure/puppeteer-ri-document-discovery.adapter.ts
@@ -132,7 +132,7 @@ export class PuppeteerRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryP
 		return records;
 	}
 
-	private normalizeOrigin(origin: string): string | null {
+	private normalizeOrigin(origin: string | null): string | null {
 		try {
 			const parsed = new URL(String(origin || '').trim());
 			if (!['http:', 'https:'].includes(parsed.protocol)) return null;

--- a/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
@@ -33,9 +33,10 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 			discover: jest.fn().mockResolvedValue([]),
 		};
 
-		// (httpAdapter, cvmAdapter, fiiAdapter, fallbackAdapter) — ITUB4 é ação,
-		// então o httpAdapter (primary) é usado como primário.
+		// (inMemoryAdapter, httpAdapter, cvmAdapter, fiiAdapter, fallbackAdapter) —
+		// ITUB4 é ação, então o httpAdapter (primary) é usado como primário.
 		const adapter = new ResilientRiDocumentDiscoveryAdapter(
+			empty,
 			primary,
 			empty,
 			empty,
@@ -69,6 +70,7 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 
 		// http (primary) vazio → cvm vazio → nenhum primário; fallback (puppeteer) retorn.
 		const adapter = new ResilientRiDocumentDiscoveryAdapter(
+			empty,
 			primary,
 			cvm,
 			empty,
@@ -101,6 +103,7 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 		};
 
 		const adapter = new ResilientRiDocumentDiscoveryAdapter(
+			{ discover: jest.fn().mockResolvedValue([]) },
 			primary,
 			{ discover: jest.fn().mockResolvedValue([]) },
 			{ discover: jest.fn().mockResolvedValue([]) },
@@ -141,6 +144,7 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 		};
 
 		const adapter = new ResilientRiDocumentDiscoveryAdapter(
+			{ discover: jest.fn().mockResolvedValue([]) },
 			primary,
 			{ discover: jest.fn().mockResolvedValue([]) },
 			{ discover: jest.fn().mockResolvedValue([]) },
@@ -159,5 +163,57 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 		expect(
 			output.some((doc) => doc.source.value.includes('fallback-avisos'))
 		).toBe(true);
+	});
+});
+
+describe('ResilientRiDocumentDiscoveryAdapter — in-memory catalog', () => {
+	function buildAdapter(overrides: {
+		inMemoryDocs?: any[];
+		httpDocs?: any[];
+	}) {
+		const inMemoryAdapter = {
+			discover: jest.fn().mockResolvedValue(overrides.inMemoryDocs || []),
+		};
+		const httpAdapter = { discover: jest.fn().mockResolvedValue(overrides.httpDocs || []) };
+		const cvmAdapter = { discover: jest.fn().mockResolvedValue([]) };
+		const fiiAdapter = { discover: jest.fn().mockResolvedValue([]) };
+		const fallbackAdapter = { discover: jest.fn().mockResolvedValue([]) };
+
+		const { ResilientRiDocumentDiscoveryAdapter } = require('./resilient-ri-document-discovery.adapter');
+		const adapter = new ResilientRiDocumentDiscoveryAdapter(
+			inMemoryAdapter,
+			httpAdapter,
+			cvmAdapter,
+			fiiAdapter,
+			fallbackAdapter,
+			1000
+		);
+		return { adapter, inMemoryAdapter, httpAdapter, cvmAdapter };
+	}
+
+	it('includes in-memory catalog documents alongside http/cvm results for a known ticker', async () => {
+		const { adapter } = buildAdapter({
+			inMemoryDocs: [{ ticker: 'PETR4', documentType: 'earnings_release', title: 'In-memory doc', source: { value: 'x' } }],
+			httpDocs: [{ ticker: 'PETR4', documentType: 'material_fact', title: 'Http doc', source: { value: 'y' } }],
+		});
+
+		const result = await adapter.discover({ ticker: 'PETR4', company: 'Petrobras', origin: 'https://petrobras.com.br/ri' });
+
+		expect(result.map((d: any) => d.title)).toEqual(
+			expect.arrayContaining(['In-memory doc', 'Http doc'])
+		);
+	});
+
+	it('still returns http/cvm documents for a ticker with no in-memory catalog entry', async () => {
+		const { adapter, inMemoryAdapter, httpAdapter } = buildAdapter({
+			inMemoryDocs: [],
+			httpDocs: [{ ticker: 'ABCD3', documentType: 'material_fact', title: 'Http doc', source: { value: 'y' } }],
+		});
+
+		const result = await adapter.discover({ ticker: 'ABCD3', company: 'Empresa', origin: 'https://ri.empresa.com.br' });
+
+		expect(inMemoryAdapter.discover).toHaveBeenCalled();
+		expect(httpAdapter.discover).toHaveBeenCalled();
+		expect(result.map((d: any) => d.title)).toEqual(['Http doc']);
 	});
 });

--- a/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
@@ -23,11 +23,18 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 	});
 
 	it('returns deduplicated primary documents when primary succeeds', async () => {
+		const primaryDocument = baseDocument('ITUB4');
+		const fallbackDocument = baseDocument('ITUB4');
+		fallbackDocument.id = 'ITUB4:material_fact:2026-02-10T00:00:00.000Z:0';
+		fallbackDocument.documentType = 'material_fact';
+		fallbackDocument.title = 'Fato Relevante';
+		fallbackDocument.source.value = 'https://ri.example.com/fallback-doc.pdf';
+
 		const primary: RiDocumentDiscoveryPort = {
-			discover: jest.fn().mockResolvedValue([baseDocument('ITUB4')]),
+			discover: jest.fn().mockResolvedValue([primaryDocument]),
 		};
 		const fallback: RiDocumentDiscoveryPort = {
-			discover: jest.fn().mockResolvedValue([baseDocument('ITUB4')]),
+			discover: jest.fn().mockResolvedValue([fallbackDocument]),
 		};
 		const empty: RiDocumentDiscoveryPort = {
 			discover: jest.fn().mockResolvedValue([]),
@@ -48,7 +55,9 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 			origin: 'https://ri.example.com',
 		});
 
-		// merge de primary (1) + fallback (1, ticker diferente) = 2 documentos.
+		// primary e fallback trazem documentos genuinamente distintos (tipos e
+		// fontes diferentes) — não devem ser colapsados pelo dedup, então o merge
+		// resulta em 2 documentos.
 		expect(output).toHaveLength(2);
 		expect(output.some((doc) => doc.ticker === 'ITUB4')).toBe(true);
 		expect(fallback.discover).toHaveBeenCalledTimes(1);

--- a/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.ts
+++ b/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.ts
@@ -10,6 +10,7 @@ export class ResilientRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryP
 	private readonly providerTimeoutMs: number;
 
 	constructor(
+		private readonly inMemoryAdapter: RiDocumentDiscoveryPort,
 		private readonly httpAdapter: RiDocumentDiscoveryPort,
 		private readonly cvmAdapter: RiDocumentDiscoveryPort,
 		private readonly fiiAdapter: RiDocumentDiscoveryPort,
@@ -21,6 +22,12 @@ export class ResilientRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryP
 
 	async discover(input: RiDocumentDiscoveryInput): Promise<RiDocumentRecord[]> {
 		const isFii = input.ticker.toUpperCase().endsWith('11');
+
+		// Catálogo em memória (tickers em destaque, curados à mão): consultado em
+		// paralelo com o restante da cadeia para não somar latência, mas usando o
+		// mesmo guard de timeout — um adapter travado não bloqueia a resposta além
+		// de providerTimeoutMs.
+		const inMemoryDocsPromise = this.safeDiscoverWithTimeout(this.inMemoryAdapter, input);
 
 		// Primário: para FIIs, o adapter específico de FII; para ações, o adapter
 		// HTTP (bate RI sites estáticos, mais rápido que Puppeteer). O CVM fica
@@ -43,11 +50,16 @@ export class ResilientRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryP
 			this.fallbackAdapter,
 			input
 		);
+		const inMemoryDocs = await inMemoryDocsPromise;
 
-		// Funde primário + fallback sem duplicatas: uma fonte pode ter o título
-		// do release de hoje e outra os PDFs históricos — juntamos ambos para a
-		// seleção de "resultado do trimestre atual" não perder o documento novo.
-		return this.mergeWithoutDuplicates(primaryDocs, fallbackDocs);
+		// Funde catálogo em memória + primário + fallback sem duplicatas: uma
+		// fonte pode ter o título do release de hoje e outra os PDFs históricos —
+		// juntamos todas para a seleção de "resultado do trimestre atual" não
+		// perder o documento novo.
+		return this.mergeWithoutDuplicates(
+			this.mergeWithoutDuplicates(inMemoryDocs, primaryDocs),
+			fallbackDocs
+		);
 	}
 
 	private async safeDiscoverWithTimeout(

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
@@ -8,6 +8,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		} as unknown as StockService;
 	}
 
+	function makeB3Registry() {
+		return { resolveCnpj: jest.fn().mockResolvedValue(null) } as any;
+	}
+
 	it('resolves ticker to normalized CNPJ ref via Brapi national quote', async () => {
 		const stockService = makeStockService({
 			results: [
@@ -18,7 +22,7 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 				},
 			],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService);
+		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
 
 		const ref = await adapter.resolveByTicker('petr4');
 
@@ -42,7 +46,7 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 				},
 			],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService);
+		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
 
 		const ref = await adapter.resolveByTicker('vale3.SA');
 
@@ -53,11 +57,11 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		});
 	});
 
-	it('returns null and skips CVM when the quote has no CNPJ', async () => {
+	it('returns null and skips CVM when the quote has no CNPJ and the B3 registry has no match either', async () => {
 		const stockService = makeStockService({
 			results: [{ symbol: 'XXXX3', longName: 'Sem CNPJ SA' }],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService);
+		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
 
 		const ref = await adapter.resolveByTicker('XXXX3');
 
@@ -68,7 +72,7 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		const stockService = {
 			getNationalQuote: jest.fn().mockRejectedValue(new Error('brapi down')),
 		} as unknown as StockService;
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService);
+		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
 
 		const ref = await adapter.resolveByTicker('ITUB4');
 
@@ -79,7 +83,7 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		const stockService = makeStockService({
 			results: [{ symbol: 'ITUB4', cnpj: '60.872.504/0001-23' }],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService);
+		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
 
 		const [a, b] = await Promise.all([
 			adapter.resolveByTicker('ITUB4'),
@@ -90,5 +94,68 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		expect(b?.cnpj).toBe('60872504000123');
 		// Apenas uma chamada Brapi para as duas invocações concorrentes.
 		expect(stockService.getNationalQuote).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
+	it('falls back to the B3 registry when Brapi has no cnpj', async () => {
+		const stockService = {
+			getNationalQuote: jest.fn().mockResolvedValue({
+				results: [{ symbol: 'ABCD3', cnpj: null, longName: null }],
+			}),
+		};
+		const b3Registry = {
+			resolveCnpj: jest.fn().mockResolvedValue({
+				cnpj: '12345678000190',
+				company: 'Empresa Real S.A.',
+			}),
+		};
+		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
+			stockService,
+			b3Registry
+		);
+
+		const result = await adapter.resolveByTicker('ABCD3');
+
+		expect(b3Registry.resolveCnpj).toHaveBeenCalledWith('ABCD3');
+		expect(result).toEqual({
+			ticker: 'ABCD3',
+			company: 'Empresa Real S.A.',
+			cnpj: '12345678000190',
+		});
+	});
+
+	it('does not call the B3 registry when Brapi already has a cnpj', async () => {
+		const stockService = {
+			getNationalQuote: jest.fn().mockResolvedValue({
+				results: [{ symbol: 'PETR4', cnpj: '33.000.167/0001-01', longName: 'Petrobras' }],
+			}),
+		};
+		const b3Registry = { resolveCnpj: jest.fn() };
+		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
+			stockService,
+			b3Registry
+		);
+
+		await adapter.resolveByTicker('PETR4');
+
+		expect(b3Registry.resolveCnpj).not.toHaveBeenCalled();
+	});
+
+	it('returns null when neither Brapi nor the B3 registry has a cnpj', async () => {
+		const stockService = {
+			getNationalQuote: jest.fn().mockResolvedValue({
+				results: [{ symbol: 'ZZZZ9', cnpj: null }],
+			}),
+		};
+		const b3Registry = { resolveCnpj: jest.fn().mockResolvedValue(null) };
+		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
+			stockService,
+			b3Registry
+		);
+
+		const result = await adapter.resolveByTicker('ZZZZ9');
+
+		expect(result).toBeNull();
 	});
 });

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
@@ -158,4 +158,63 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 
 		expect(result).toBeNull();
 	});
+
+	it('does not poison the 6h negative cache when the B3 registry lookup itself fails (transient), so a later lookup retries it', async () => {
+		const stockService = {
+			getNationalQuote: jest.fn().mockResolvedValue({
+				results: [{ symbol: 'WXYZ3', cnpj: null }],
+			}),
+		};
+		const b3Registry = {
+			resolveCnpj: jest
+				.fn()
+				.mockRejectedValueOnce(new Error('b3 registry unreachable'))
+				.mockResolvedValueOnce({
+					cnpj: '98765432000111',
+					company: 'Empresa Recuperada S.A.',
+				}),
+		};
+		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
+			stockService,
+			b3Registry
+		);
+
+		const first = await adapter.resolveByTicker('WXYZ3');
+		expect(first).toBeNull();
+
+		// Uma segunda tentativa logo em seguida deve tentar o registro B3 de
+		// novo (não deve estar servindo um cache negativo de 6h construído a
+		// partir de uma falha transitória de rede).
+		const second = await adapter.resolveByTicker('WXYZ3');
+
+		expect(b3Registry.resolveCnpj).toHaveBeenCalledTimes(2);
+		expect(second).toEqual({
+			ticker: 'WXYZ3',
+			company: 'Empresa Recuperada S.A.',
+			cnpj: '98765432000111',
+		});
+	});
+
+	it('does write the 6h negative cache when the B3 registry loads successfully but genuinely has no match', async () => {
+		const stockService = {
+			getNationalQuote: jest.fn().mockResolvedValue({
+				results: [{ symbol: 'NOPE3', cnpj: null }],
+			}),
+		};
+		const b3Registry = { resolveCnpj: jest.fn().mockResolvedValue(null) };
+		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
+			stockService,
+			b3Registry
+		);
+
+		const first = await adapter.resolveByTicker('NOPE3');
+		const second = await adapter.resolveByTicker('NOPE3');
+
+		expect(first).toBeNull();
+		expect(second).toBeNull();
+		// Cache negativo válido (registro carregou com sucesso, ticker
+		// genuinamente ausente): segunda chamada não deve re-consultar nada.
+		expect(b3Registry.resolveCnpj).toHaveBeenCalledTimes(1);
+		expect(stockService.getNationalQuote).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
@@ -3,6 +3,7 @@ import {
 	RiIssuerCatalogPort,
 	RiIssuerRef,
 } from 'src/ri-intelligence/application/ri-issuer-catalog.port';
+import { B3RegistryCnpjResolverAdapter } from 'src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter';
 import { StockService } from 'src/stocks/stocks.service';
 
 /**
@@ -26,7 +27,10 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 	private readonly inflight = new Map<string, Promise<RiIssuerRef | null>>();
 	private readonly ttlMs = 6 * 60 * 60 * 1000;
 
-	constructor(private readonly stockService: StockService) {}
+	constructor(
+		private readonly stockService: StockService,
+		private readonly b3Registry: B3RegistryCnpjResolverAdapter
+	) {}
 
 	async resolveByTicker(ticker: string): Promise<RiIssuerRef | null> {
 		const normalizedTicker = String(ticker || '')
@@ -49,10 +53,29 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 					{ fundamental: true }
 				);
 				const stock = response?.results?.[0];
-				const cnpj = this.normalizeCnpj(stock?.cnpj);
+				let cnpj = this.normalizeCnpj(stock?.cnpj);
+				let company: string =
+					stock?.longName || stock?.shortName || normalizedTicker;
+
+				if (!cnpj) {
+					try {
+						const registryMatch = await this.b3Registry.resolveCnpj(
+							normalizedTicker
+						);
+						if (registryMatch) {
+							cnpj = registryMatch.cnpj;
+							company = registryMatch.company || company;
+						}
+					} catch (error) {
+						this.logger.warn(
+							`Falha ao consultar registro B3 para ${normalizedTicker}: ${error?.message || error}`
+						);
+					}
+				}
+
 				if (!cnpj) {
 					this.logger.debug(
-						`Sem CNPJ na cotação de ${normalizedTicker}; descoberta CVM indisponível`
+						`Sem CNPJ na cotação nem no registro B3 de ${normalizedTicker}; descoberta CVM indisponível`
 					);
 					this.cache.set(normalizedTicker, {
 						expiresAt: Date.now() + this.ttlMs,
@@ -60,8 +83,7 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 					});
 					return null;
 				}
-				const company: string =
-					stock?.longName || stock?.shortName || normalizedTicker;
+
 				const ref: RiIssuerRef = {
 					ticker: normalizedTicker,
 					company,

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
@@ -57,6 +57,7 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 				let company: string =
 					stock?.longName || stock?.shortName || normalizedTicker;
 
+				let b3RegistryFailed = false;
 				if (!cnpj) {
 					try {
 						const registryMatch = await this.b3Registry.resolveCnpj(
@@ -67,6 +68,11 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 							company = registryMatch.company || company;
 						}
 					} catch (error) {
+						// Falha ao CARREGAR o registro B3 (rede, parsing, etc.) é
+						// transitória — não confirma que o ticker não existe. Não
+						// deve poluir o cache negativo de 6h (mesmo tratamento que
+						// já damos à falha da Brapi no catch externo).
+						b3RegistryFailed = true;
 						this.logger.warn(
 							`Falha ao consultar registro B3 para ${normalizedTicker}: ${error?.message || error}`
 						);
@@ -74,6 +80,12 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 				}
 
 				if (!cnpj) {
+					if (b3RegistryFailed) {
+						this.logger.debug(
+							`Registro B3 indisponível para ${normalizedTicker} (falha transitória); não armazenando cache negativo de 6h`
+						);
+						return null;
+					}
 					this.logger.debug(
 						`Sem CNPJ na cotação nem no registro B3 de ${normalizedTicker}; descoberta CVM indisponível`
 					);

--- a/src/ri-intelligence/ri-intelligence.module.ts
+++ b/src/ri-intelligence/ri-intelligence.module.ts
@@ -5,6 +5,8 @@ import { RI_ASSET_AUTOCOMPLETE } from 'src/ri-intelligence/application/ri-asset-
 import { RiDocumentCatalogService } from 'src/ri-intelligence/application/ri-document-catalog.service';
 import { RI_DOCUMENT_DISCOVERY } from 'src/ri-intelligence/application/ri-document-discovery.port';
 import { RI_DOCUMENT_LINK_RESOLVER } from 'src/ri-intelligence/application/ri-document-link-resolver.port';
+import { RI_ORIGIN_SEARCH } from 'src/ri-intelligence/application/ri-origin-search.port';
+import { GoogleCseRiOriginSearchAdapter } from 'src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter';
 import { RiDocumentSummaryService } from 'src/ri-intelligence/application/ri-document-summary.service';
 import { RI_DOCUMENT_QUERY } from 'src/ri-intelligence/application/ri-document-query.port';
 import { RI_ISSUER_CATALOG } from 'src/ri-intelligence/application/ri-issuer-catalog.port';
@@ -35,6 +37,11 @@ import { PuppeteerBrowserPool } from 'src/ri-intelligence/infrastructure/puppete
 		HttpRiDocumentDiscoveryAdapter,
 		HttpRiDocumentLinkResolverAdapter,
 		CatalogRiDocumentQueryAdapter,
+		GoogleCseRiOriginSearchAdapter,
+		{
+			provide: RI_ORIGIN_SEARCH,
+			useExisting: GoogleCseRiOriginSearchAdapter,
+		},
 		{
 			provide: RI_SUMMARY_CACHE,
 			useClass: InMemoryRiSummaryCacheAdapter,

--- a/src/ri-intelligence/ri-intelligence.module.ts
+++ b/src/ri-intelligence/ri-intelligence.module.ts
@@ -16,6 +16,7 @@ import { InMemoryRiDocumentDiscoveryAdapter } from 'src/ri-intelligence/infrastr
 import { InMemoryRiSummaryCacheAdapter } from 'src/ri-intelligence/infrastructure/in-memory-ri-summary-cache.adapter';
 import { StocksRiAssetAutocompleteAdapter } from 'src/ri-intelligence/infrastructure/stocks-ri-asset-autocomplete.adapter';
 import { StocksRiIssuerCatalogAdapter } from 'src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter';
+import { B3RegistryCnpjResolverAdapter } from 'src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter';
 import { RiIntelligenceController } from 'src/ri-intelligence/ri-intelligence.controller';
 import { HttpRiDocumentDiscoveryAdapter } from 'src/ri-intelligence/infrastructure/http-ri-document-discovery.adapter';
 import { ResilientRiDocumentDiscoveryAdapter } from 'src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter';
@@ -32,6 +33,7 @@ import { PuppeteerBrowserPool } from 'src/ri-intelligence/infrastructure/puppete
 		RiDocumentCatalogService,
 		RiDocumentSummaryService,
 		StocksRiAssetAutocompleteAdapter,
+		B3RegistryCnpjResolverAdapter,
 		StocksRiIssuerCatalogAdapter,
 		InMemoryRiDocumentDiscoveryAdapter,
 		HttpRiDocumentDiscoveryAdapter,

--- a/src/ri-intelligence/ri-intelligence.module.ts
+++ b/src/ri-intelligence/ri-intelligence.module.ts
@@ -63,18 +63,21 @@ import { PuppeteerBrowserPool } from 'src/ri-intelligence/infrastructure/puppete
 		{
 			provide: RI_DOCUMENT_DISCOVERY,
 			useFactory: (
+				inMemoryAdapter: InMemoryRiDocumentDiscoveryAdapter,
 				httpAdapter: HttpRiDocumentDiscoveryAdapter,
 				cvmAdapter: CvmRiDocumentDiscoveryAdapter,
 				fiiAdapter: FiiRiDocumentDiscoveryAdapter,
 				puppeteerAdapter: PuppeteerRiDocumentDiscoveryAdapter
 			) =>
 				new ResilientRiDocumentDiscoveryAdapter(
+					inMemoryAdapter,
 					httpAdapter,
 					cvmAdapter,
 					fiiAdapter,
 					puppeteerAdapter
 				),
 			inject: [
+				InMemoryRiDocumentDiscoveryAdapter,
 				HttpRiDocumentDiscoveryAdapter,
 				CvmRiDocumentDiscoveryAdapter,
 				FiiRiDocumentDiscoveryAdapter,


### PR DESCRIPTION
## Summary
- RI Inteligente previously found zero documents for any company outside a hardcoded list of 5 (BBDC4, ITUB4, BBAS3, PETR4, VALE3), because it fabricated a fake investor-relations URL (`https://ri.{company-slug}.com.br`) that almost never exists.
- Stops guessing; adds Google Custom Search as a fallback to find the real IR domain, and a B3 company registry as a second CNPJ source (needed for CVM document lookup) when Brapi's data is incomplete.
- Wires an orphaned, already-built document catalog for the 5 featured tickers into the actual discovery chain (it was registered but never consulted).
- Requires two new **optional** env vars (`GOOGLE_CSE_API_KEY`, `GOOGLE_CSE_ENGINE_ID`) — the feature degrades gracefully to CVM-only discovery when unset.

## Caught by the final whole-branch review (fixed in this branch)
- **Critical:** Google CSE was being called once per *document* instead of once per *company* — up to ~160 calls for a single search, which would have exhausted the free API quota on the first real use. Fixed by resolving the origin once and threading it through.
- **Important:** a transient B3 registry failure (undocumented third-party endpoint) was being cached as a 6-hour negative CNPJ result, indistinguishable from "this ticker genuinely has no CNPJ." Fixed by distinguishing load-failure from not-found.
- **Important:** Google CSE could return a financial news aggregator (statusinvest, infomoney, etc.) as if it were the issuer's own IR site. Added a deny-list so aggregator hosts are treated as "not found" instead of crawled.
- Also fixed a pre-existing broken test unrelated to this branch's core changes, found along the way.

## Test plan
- [x] 434/436 passing — the 2 failures are pre-existing and unrelated to `ri-intelligence` (`ai/ai.controller.spec.ts`).
- [x] `tsc --noEmit`: only 2 pre-existing unrelated errors in `src/fiscal/` (puppeteer typing).
- [ ] Manual: search RI Inteligente for a company outside the 5 hardcoded tickers; if `GOOGLE_CSE_*` is configured, confirm documents are found via the resolved real IR domain; confirm CVM-only discovery still works with those env vars unset.
- [ ] Set `GOOGLE_CSE_API_KEY`/`GOOGLE_CSE_ENGINE_ID` in the target environment before this feature has any effect beyond the 5 known companies + whatever CVM/CNPJ can resolve without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)