### PR TITLE
fix(ci): send Coolify API token in deploy webhook auth header

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,21 +22,28 @@ jobs:
       - name: Validate webhook secret
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         run: |
           if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
             echo "Missing required secret: COOLIFY_WEBHOOK_URL"
+            exit 1
+          fi
+          if [ -z "$COOLIFY_API_TOKEN" ]; then
+            echo "Missing required secret: COOLIFY_API_TOKEN"
             exit 1
           fi
 
       - name: Trigger deploy on Coolify
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           curl --fail --show-error --silent \
             -X POST "$COOLIFY_WEBHOOK_URL" \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"sha\":\"$GITHUB_SHA\",\"branch\":\"$GITHUB_REF_NAME\",\"repository\":\"$GITHUB_REPOSITORY\"}"
           echo "Coolify deploy triggered successfully."


### PR DESCRIPTION
## Summary
- The Coolify deploy webhook is configured as "auth required," but `deploy.yml` never sent an `Authorization` header — every deploy trigger would 401.
- Adds `COOLIFY_API_TOKEN` as a required secret, sent as `Authorization: Bearer $COOLIFY_API_TOKEN`.
- Both `COOLIFY_WEBHOOK_URL` and `COOLIFY_API_TOKEN` secrets are already configured on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)