### PR TITLE
feat(server): add purchase-intent lead capture endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Resend
 RESEND_API_KEY=""
 RESEND_FROM=""
+RESEND_AUDIENCE_ID=""
 
 # Frontend
 FRONTEND_URL=""

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { FiscalModule } from './fiscal/fiscal.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { EndpointRateLimitMiddleware } from 'src/security/rate-limit/endpoint-rate-limit.middleware';
 import { AdminModule } from './admin/admin.module';
+import { LeadsModule } from './leads/leads.module';
 
 @Module({
 	imports: [
@@ -45,6 +46,7 @@ import { AdminModule } from './admin/admin.module';
 		PortfolioModule,
 		FiscalModule,
 		AdminModule,
+		LeadsModule,
 	],
 	controllers: [AppController],
 	providers: [

--- a/src/leads/dto/purchase-intent.dto.spec.ts
+++ b/src/leads/dto/purchase-intent.dto.spec.ts
@@ -1,0 +1,34 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { PurchaseIntentDto } from './purchase-intent.dto';
+
+describe('PurchaseIntentDto', () => {
+	it('passes validation with a valid email and plan name', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('fails validation with an invalid email', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'not-an-email',
+			planName: 'Premium',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0].property).toBe('email');
+	});
+
+	it('fails validation with an empty plan name', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planName: '',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0].property).toBe('planName');
+	});
+});

--- a/src/leads/dto/purchase-intent.dto.spec.ts
+++ b/src/leads/dto/purchase-intent.dto.spec.ts
@@ -31,4 +31,33 @@ describe('PurchaseIntentDto', () => {
 		expect(errors.length).toBeGreaterThan(0);
 		expect(errors[0].property).toBe('planName');
 	});
+
+	it('passes validation with the other whitelisted plan name', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planName: 'Global Investor',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('fails validation with a plan name outside the whitelist', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planName: 'NotARealPlan',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0].property).toBe('planName');
+	});
+
+	it('fails validation when plan name contains HTML/script injection attempts', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planName: '<script>alert(1)</script>',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0].property).toBe('planName');
+	});
 });

--- a/src/leads/dto/purchase-intent.dto.ts
+++ b/src/leads/dto/purchase-intent.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsIn } from 'class-validator';
 
 export class PurchaseIntentDto {
 	@ApiProperty({
@@ -13,7 +13,6 @@ export class PurchaseIntentDto {
 		description: 'Nome do plano que gerou o interesse',
 		example: 'Premium',
 	})
-	@IsString()
-	@IsNotEmpty({ message: 'O nome do plano é obrigatório' })
+	@IsIn(['Premium', 'Global Investor'], { message: 'Plano inválido' })
 	planName: string;
 }

--- a/src/leads/dto/purchase-intent.dto.ts
+++ b/src/leads/dto/purchase-intent.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class PurchaseIntentDto {
+	@ApiProperty({
+		description: 'E-mail do visitante interessado no plano',
+		example: 'investidor@example.com',
+	})
+	@IsEmail({}, { message: 'Informe um e-mail válido' })
+	email: string;
+
+	@ApiProperty({
+		description: 'Nome do plano que gerou o interesse',
+		example: 'Premium',
+	})
+	@IsString()
+	@IsNotEmpty({ message: 'O nome do plano é obrigatório' })
+	planName: string;
+}

--- a/src/leads/leads.controller.spec.ts
+++ b/src/leads/leads.controller.spec.ts
@@ -1,0 +1,22 @@
+import { LeadsController } from './leads.controller';
+import { PurchaseIntentService } from './leads.service';
+
+describe('LeadsController', () => {
+	it('delegates to PurchaseIntentService.captureIntent and returns its result', async () => {
+		const purchaseIntentService = {
+			captureIntent: jest.fn().mockResolvedValue({ success: true }),
+		} as unknown as PurchaseIntentService;
+		const controller = new LeadsController(purchaseIntentService);
+
+		const result = await controller.capturePurchaseIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(purchaseIntentService.captureIntent).toHaveBeenCalledWith({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+		expect(result).toEqual({ success: true });
+	});
+});

--- a/src/leads/leads.controller.ts
+++ b/src/leads/leads.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from 'src/utils/constants';
+import { PurchaseIntentDto } from './dto/purchase-intent.dto';
+import { PurchaseIntentService } from './leads.service';
+
+@Controller('leads')
+@ApiTags('leads')
+export class LeadsController {
+	constructor(private readonly purchaseIntentService: PurchaseIntentService) {}
+
+	@Public()
+	@Post('purchase-intent')
+	@ApiOkResponse({ schema: { example: { success: true } } })
+	async capturePurchaseIntent(@Body() dto: PurchaseIntentDto) {
+		return this.purchaseIntentService.captureIntent(dto);
+	}
+}

--- a/src/leads/leads.module.ts
+++ b/src/leads/leads.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { EmailModule } from 'src/notifications/email/email.module';
+import { LeadsController } from './leads.controller';
+import { PurchaseIntentService } from './leads.service';
+
+@Module({
+	imports: [EmailModule],
+	controllers: [LeadsController],
+	providers: [PurchaseIntentService],
+})
+export class LeadsModule {}

--- a/src/leads/leads.service.spec.ts
+++ b/src/leads/leads.service.spec.ts
@@ -53,7 +53,7 @@ describe('PurchaseIntentService', () => {
 		).toHaveBeenCalledWith('investidor@example.com', 'Premium');
 	});
 
-	it('returns success even when the Resend contact creation fails', async () => {
+	it('returns success even when the Resend contact creation throws', async () => {
 		const failingCreate = jest.fn().mockRejectedValue(new Error('Resend down'));
 		const { service } = buildService({ resendContactsCreate: failingCreate });
 		process.env.RESEND_AUDIENCE_ID = 'audience_123';
@@ -64,6 +64,27 @@ describe('PurchaseIntentService', () => {
 		});
 
 		expect(result).toEqual({ success: true });
+	});
+
+	it('logs a warning and returns success when the Resend contact creation resolves with an error', async () => {
+		const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+		const errorCreate = jest
+			.fn()
+			.mockResolvedValue({ data: null, error: { message: 'some error' } });
+		const { service } = buildService({ resendContactsCreate: errorCreate });
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+
+		const result = await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'Falha ao adicionar contato na audience do Resend: some error'
+		);
+		expect(result).toEqual({ success: true });
+
+		warnSpy.mockRestore();
 	});
 
 	it('returns success even when sending the confirmation email fails', async () => {

--- a/src/leads/leads.service.spec.ts
+++ b/src/leads/leads.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { PurchaseIntentService } from './leads.service';
 import { EmailService } from 'src/notifications/email/email.service';
 
@@ -91,5 +92,37 @@ describe('PurchaseIntentService', () => {
 
 		expect(resendContactsCreate).not.toHaveBeenCalled();
 		expect(result).toEqual({ success: true });
+	});
+
+	it('logs a warning and skips the Resend contact call when RESEND_API_KEY is not configured but RESEND_AUDIENCE_ID is', async () => {
+		const originalApiKey = process.env.RESEND_API_KEY;
+		delete process.env.RESEND_API_KEY;
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+
+		const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest
+				.fn()
+				.mockResolvedValue(undefined),
+		} as unknown as EmailService;
+
+		const service = new PurchaseIntentService(emailService);
+
+		const result = await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'RESEND_API_KEY não configurado; pulando criação de contato na audience'
+		);
+		expect(result).toEqual({ success: true });
+
+		warnSpy.mockRestore();
+		if (originalApiKey === undefined) {
+			delete process.env.RESEND_API_KEY;
+		} else {
+			process.env.RESEND_API_KEY = originalApiKey;
+		}
 	});
 });

--- a/src/leads/leads.service.spec.ts
+++ b/src/leads/leads.service.spec.ts
@@ -1,0 +1,95 @@
+import { PurchaseIntentService } from './leads.service';
+import { EmailService } from 'src/notifications/email/email.service';
+
+describe('PurchaseIntentService', () => {
+	function buildService(overrides?: { resendContactsCreate?: jest.Mock }) {
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest
+				.fn()
+				.mockResolvedValue(undefined),
+		} as unknown as EmailService;
+		const resendContactsCreate =
+			overrides?.resendContactsCreate ??
+			jest.fn().mockResolvedValue({ data: { id: 'contact_1' } });
+		const resendClient = { contacts: { create: resendContactsCreate } };
+
+		const service = new PurchaseIntentService(
+			emailService,
+			resendClient as any
+		);
+		return { service, emailService, resendContactsCreate };
+	}
+
+	it('adds the contact to the Resend audience with the plan name as a property', async () => {
+		const { service, resendContactsCreate } = buildService();
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+
+		await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(resendContactsCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				audienceId: 'audience_123',
+				email: 'investidor@example.com',
+				properties: expect.objectContaining({ planName: 'Premium' }),
+			})
+		);
+	});
+
+	it('sends the confirmation email', async () => {
+		const { service, emailService } = buildService();
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+
+		await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(
+			emailService.sendPurchaseIntentConfirmationEmail
+		).toHaveBeenCalledWith('investidor@example.com', 'Premium');
+	});
+
+	it('returns success even when the Resend contact creation fails', async () => {
+		const failingCreate = jest.fn().mockRejectedValue(new Error('Resend down'));
+		const { service } = buildService({ resendContactsCreate: failingCreate });
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+
+		const result = await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('returns success even when sending the confirmation email fails', async () => {
+		const { service, emailService } = buildService();
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+		(
+			emailService.sendPurchaseIntentConfirmationEmail as jest.Mock
+		).mockRejectedValue(new Error('email provider down'));
+
+		const result = await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('skips the Resend contact call when RESEND_AUDIENCE_ID is not configured', async () => {
+		const { service, resendContactsCreate } = buildService();
+		delete process.env.RESEND_AUDIENCE_ID;
+
+		const result = await service.captureIntent({
+			email: 'investidor@example.com',
+			planName: 'Premium',
+		});
+
+		expect(resendContactsCreate).not.toHaveBeenCalled();
+		expect(result).toEqual({ success: true });
+	});
+});

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -22,11 +22,17 @@ export class PurchaseIntentService {
 
 		if (audienceId && this.resendClient?.contacts) {
 			try {
-				await this.resendClient.contacts.create({
+				const { error } = await this.resendClient.contacts.create({
 					audienceId,
 					email: dto.email,
 					properties: { planName: dto.planName },
 				} as Parameters<Resend['contacts']['create']>[0]);
+
+				if (error) {
+					this.logger.warn(
+						`Falha ao adicionar contato na audience do Resend: ${error?.message || error}`
+					);
+				}
 			} catch (error) {
 				this.logger.warn(
 					`Falha ao adicionar contato na audience do Resend: ${error?.message || error}`

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -36,6 +36,10 @@ export class PurchaseIntentService {
 			this.logger.warn(
 				'RESEND_AUDIENCE_ID não configurado; pulando criação de contato na audience'
 			);
+		} else {
+			this.logger.warn(
+				'RESEND_API_KEY não configurado; pulando criação de contato na audience'
+			);
 		}
 
 		try {

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Resend } from 'resend';
+import { EmailService } from 'src/notifications/email/email.service';
+import { PurchaseIntentDto } from './dto/purchase-intent.dto';
+
+@Injectable()
+export class PurchaseIntentService {
+	private readonly logger = new Logger(PurchaseIntentService.name);
+	private readonly resendClient: Pick<Resend, 'contacts'>;
+
+	constructor(
+		private readonly emailService: EmailService,
+		@Optional() resendClient?: Pick<Resend, 'contacts'>
+	) {
+		const apiKey = process.env.RESEND_API_KEY;
+		this.resendClient =
+			resendClient ?? (apiKey ? new Resend(apiKey) : ({} as Resend));
+	}
+
+	async captureIntent(dto: PurchaseIntentDto): Promise<{ success: true }> {
+		const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+		if (audienceId && this.resendClient?.contacts) {
+			try {
+				await this.resendClient.contacts.create({
+					audienceId,
+					email: dto.email,
+					properties: { planName: dto.planName },
+				} as Parameters<Resend['contacts']['create']>[0]);
+			} catch (error) {
+				this.logger.warn(
+					`Falha ao adicionar contato na audience do Resend: ${error?.message || error}`
+				);
+			}
+		} else if (!audienceId) {
+			this.logger.warn(
+				'RESEND_AUDIENCE_ID não configurado; pulando criação de contato na audience'
+			);
+		}
+
+		try {
+			await this.emailService.sendPurchaseIntentConfirmationEmail(
+				dto.email,
+				dto.planName
+			);
+		} catch (error) {
+			this.logger.warn(
+				`Falha ao enviar e-mail de confirmação de interesse: ${error?.message || error}`
+			);
+		}
+
+		return { success: true };
+	}
+}

--- a/src/notifications/email/email.service.spec.ts
+++ b/src/notifications/email/email.service.spec.ts
@@ -1,0 +1,31 @@
+import { EmailService } from './email.service';
+import { EmailSender } from './ports/email-sender.port';
+
+describe('EmailService', () => {
+	function buildService() {
+		const sender: EmailSender = {
+			send: jest.fn().mockResolvedValue(undefined),
+		};
+		const service = new EmailService(sender);
+		return { service, sender };
+	}
+
+	describe('sendPurchaseIntentConfirmationEmail', () => {
+		it('sends a confirmation email mentioning the plan name', async () => {
+			const { service, sender } = buildService();
+
+			await service.sendPurchaseIntentConfirmationEmail(
+				'investidor@example.com',
+				'Premium'
+			);
+
+			expect(sender.send).toHaveBeenCalledWith(
+				expect.objectContaining({
+					to: 'investidor@example.com',
+					subject: expect.stringContaining('Premium'),
+					html: expect.stringContaining('Premium'),
+				})
+			);
+		});
+	});
+});

--- a/src/notifications/email/email.service.ts
+++ b/src/notifications/email/email.service.ts
@@ -93,4 +93,28 @@ export class EmailService {
 			text,
 		});
 	}
+
+	async sendPurchaseIntentConfirmationEmail(
+		email: string,
+		planName: string
+	): Promise<void> {
+		const subject = `Recebemos seu interesse no plano ${planName} - Trakker`;
+		const html = this.getBaseTemplate({
+			title: `Interesse registrado: ${planName}`,
+			hero: 'Estamos finalizando os acessos para o seu setor',
+			description: `Recebemos seu interesse no plano ${planName}. Nossa equipe está priorizando os próximos convites — você vai receber um e-mail assim que seu acesso estiver liberado.`,
+			ctaLabel: 'Conhecer o Trakker',
+			ctaUrl: this.getAppBaseUrl(),
+			footerNote:
+				'Se você não solicitou este contato, pode ignorar este e-mail com segurança.',
+		});
+		const text = `Interesse registrado: ${planName}\n\nRecebemos seu interesse no plano ${planName}. Você vai receber um e-mail assim que seu acesso estiver liberado.`;
+
+		await this.sender.send({
+			to: email,
+			subject,
+			html,
+			text,
+		});
+	}
 }

--- a/src/security/rate-limit/endpoint-rate-limit.middleware.spec.ts
+++ b/src/security/rate-limit/endpoint-rate-limit.middleware.spec.ts
@@ -94,4 +94,37 @@ describe('EndpointRateLimitMiddleware', () => {
 		);
 		expect(() => middleware.use(reqB, res, next)).not.toThrow();
 	});
+
+	it('applies a tight limit to POST:/leads/purchase-intent', () => {
+		const middleware = new EndpointRateLimitMiddleware();
+		const req: any = {
+			method: 'POST',
+			path: '/leads/purchase-intent',
+			ip: '127.0.0.1',
+			headers: {
+				'user-agent': 'jest',
+				'accept-language': 'pt-BR',
+			},
+			socket: { remoteAddress: '127.0.0.1' },
+		};
+		const res: any = { setHeader: jest.fn() };
+		const next = jest.fn();
+
+		for (let i = 0; i < 5; i += 1) {
+			middleware.use(req, res, next);
+		}
+
+		expect(next).toHaveBeenCalledTimes(5);
+
+		let thrown: unknown;
+		try {
+			middleware.use(req, res, next);
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(HttpException);
+		expect((thrown as HttpException).getStatus()).toBe(
+			HttpStatus.TOO_MANY_REQUESTS
+		);
+	});
 });

--- a/src/security/rate-limit/endpoint-rate-limit.middleware.ts
+++ b/src/security/rate-limit/endpoint-rate-limit.middleware.ts
@@ -30,6 +30,7 @@ export class EndpointRateLimitMiddleware implements NestMiddleware {
 		'POST:/auth/google/signin': { limit: 12, windowMs: 60_000 },
 		'POST:/auth/forgot-password': { limit: 8, windowMs: 60_000 },
 		'POST:/broker-sync/upload-note': { limit: 20, windowMs: 10 * 60_000 },
+		'POST:/leads/purchase-intent': { limit: 5, windowMs: 60_000 },
 	};
 	private cleanupTimer: NodeJS.Timeout | null = null;
 


### PR DESCRIPTION
## Summary
- New public `POST /leads/purchase-intent` endpoint (`{email, planName}`) — used by the landing page's "fake CTA" purchase-intent modal (companion `web` PR). Adds the contact to a Resend Audience and sends a confirmation email, no real billing.
- Every external-provider failure (Resend contacts API, confirmation email) is caught and logged; the endpoint always returns `{success: true}` once validation passes — a marketing-list hiccup can never surface as an error to a landing-page visitor.

## Caught by the final whole-branch review (fixed in this branch)
- **Critical:** `planName` was validated only as non-empty and interpolated raw into the outbound confirmation email's HTML — on a fully anonymous endpoint, this was a phishing vector (arbitrary HTML/links delivered to any victim email, from the company's verified sending domain). Fixed by whitelisting `planName` to the two real plan names (`Premium`, `Global Investor`).
- **Important:** the Resend SDK returns `{data, error}` on API failures rather than throwing, but the contact-creation call only had a try/catch and never inspected the result — a bad audience ID or quota issue silently lost the lead with zero log signal. Fixed by checking and logging the `error` field.
- **Important:** the endpoint had no rate limit, inheriting the middleware's loose 300 req/min default — versus 8/min on the analogous unauthenticated `POST /auth/forgot-password`. Added a 5 req/min rule.

## Requires (before this has any effect beyond logging)
- `RESEND_API_KEY`, `RESEND_FROM` (already used for transactional email) and a new `RESEND_AUDIENCE_ID` — create an Audience in the Resend dashboard first, and a `planName` contact property if the Resend API requires pre-registered properties.

## Test plan
- [x] 463/465 passing — the 2 failures are pre-existing and unrelated (`ai/ai.controller.spec.ts`).
- [x] `type-check`/`lint` clean.
- [ ] Manual: `POST /leads/purchase-intent` with a valid email + `planName: "Premium"` — confirm the contact appears in the Resend Audience and the confirmation email arrives; confirm a non-whitelisted `planName` gets a 400; confirm the 6th request within 60s from the same IP gets rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)