### PR TITLE
feat(server): billing plan/price consistency (monthly/annual)

### DIFF
--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { NotFoundException } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { StripeService } from 'src/subscription/stripe.service';
+
+jest.mock('../env.ts', () => ({
+	jwtSecret: 'fakeJwtSecretsdadxczxc,mfnlfnvlvnvlzmxcmv',
+}));
+
+describe('AdminService — updatePlan', () => {
+	let service: AdminService;
+	let mockSubscriptionModel: any;
+	let mockUserModel: any;
+	let mockUserSubscriptionModel: any;
+	let mockManualGrantAuditModel: any;
+	let mockStripeService: any;
+
+	function buildPlan(overrides: Record<string, any> = {}) {
+		const plan: any = {
+			_id: 'plan_1',
+			name: 'Plano Mensal',
+			description: 'Descrição',
+			price: 49,
+			currency: 'brl',
+			interval: 'month',
+			intervalCount: 1,
+			stripeProductId: 'prod_123',
+			stripePriceId: 'price_monthly_old',
+			annualPrice: undefined,
+			annualStripePriceId: undefined,
+			isActive: true,
+			...overrides,
+		};
+		plan.save = jest.fn().mockResolvedValue(plan);
+		return plan;
+	}
+
+	beforeEach(async () => {
+		mockSubscriptionModel = { findById: jest.fn() };
+		mockUserModel = { findOne: jest.fn() };
+		mockUserSubscriptionModel = {};
+		mockManualGrantAuditModel = {};
+		mockStripeService = {
+			updateProduct: jest.fn().mockResolvedValue({}),
+			createPrice: jest.fn().mockResolvedValue({ id: 'price_monthly_new' }),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				AdminService,
+				{ provide: getModelToken('User'), useValue: mockUserModel },
+				{
+					provide: getModelToken('Subscription'),
+					useValue: mockSubscriptionModel,
+				},
+				{
+					provide: getModelToken('UserSubscription'),
+					useValue: mockUserSubscriptionModel,
+				},
+				{
+					provide: getModelToken('ManualGrantAudit'),
+					useValue: mockManualGrantAuditModel,
+				},
+				{ provide: StripeService, useValue: mockStripeService },
+			],
+		}).compile();
+
+		service = module.get<AdminService>(AdminService);
+	});
+
+	it('throws NotFoundException when plan does not exist', async () => {
+		mockSubscriptionModel.findById.mockResolvedValue(null);
+		await expect(
+			service.updatePlan('missing', { name: 'X' } as any)
+		).rejects.toThrow(NotFoundException);
+	});
+
+	it('persists annualPrice and annualStripePriceId from the update payload', async () => {
+		const plan = buildPlan();
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+
+		const result = await service.updatePlan('plan_1', {
+			annualPrice: 411.6,
+			annualStripePriceId: 'price_annual_new',
+		} as any);
+
+		expect(result.annualPrice).toBe(411.6);
+		expect(result.annualStripePriceId).toBe('price_annual_new');
+		expect(plan.save).toHaveBeenCalled();
+	});
+
+	it('keeps existing annual fields untouched when not present in the update payload', async () => {
+		const plan = buildPlan({
+			annualPrice: 400,
+			annualStripePriceId: 'price_annual_existing',
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+
+		const result = await service.updatePlan('plan_1', {
+			name: 'Novo nome',
+		} as any);
+
+		expect(result.annualPrice).toBe(400);
+		expect(result.annualStripePriceId).toBe('price_annual_existing');
+	});
+
+	it('logs a warning when a monthly price change leaves an existing annualStripePriceId unexamined', async () => {
+		const plan = buildPlan({
+			annualPrice: 400,
+			annualStripePriceId: 'price_annual_existing',
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+		const warnSpy = jest
+			.spyOn((service as any).logger, 'warn')
+			.mockImplementation(() => undefined);
+
+		await service.updatePlan('plan_1', { price: 59 } as any);
+
+		expect(mockStripeService.createPrice).toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('annualStripePriceId')
+		);
+	});
+
+	it('does not warn when the update payload also updates annualStripePriceId alongside a monthly price change', async () => {
+		const plan = buildPlan({
+			annualPrice: 400,
+			annualStripePriceId: 'price_annual_existing',
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+		const warnSpy = jest
+			.spyOn((service as any).logger, 'warn')
+			.mockImplementation(() => undefined);
+
+		await service.updatePlan('plan_1', {
+			price: 59,
+			annualStripePriceId: 'price_annual_new',
+		} as any);
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not warn when there is no pre-existing annualStripePriceId to desync', async () => {
+		const plan = buildPlan();
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+		const warnSpy = jest
+			.spyOn((service as any).logger, 'warn')
+			.mockImplementation(() => undefined);
+
+		await service.updatePlan('plan_1', { price: 59 } as any);
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -103,6 +103,9 @@ export class AdminService implements OnModuleInit {
 		const nextCurrency = dto.currency ?? plan.currency;
 		const nextInterval = dto.interval ?? plan.interval;
 		const nextIntervalCount = dto.intervalCount ?? plan.intervalCount;
+		const nextAnnualPrice = dto.annualPrice ?? plan.annualPrice;
+		const nextAnnualStripePriceId =
+			dto.annualStripePriceId ?? plan.annualStripePriceId;
 
 		if (
 			(dto.name && dto.name !== plan.name) ||
@@ -138,6 +141,20 @@ export class AdminService implements OnModuleInit {
 				nextIntervalCount
 			);
 			plan.stripePriceId = stripePrice.id;
+
+			// O novo preço mensal não tem relação automática com o preço anual
+			// já configurado. Se o admin não atualizar annualStripePriceId
+			// nesta mesma requisição, os dois preços podem ficar dessincronizados.
+			const annualUnchanged =
+				dto.annualStripePriceId === undefined ||
+				dto.annualStripePriceId === plan.annualStripePriceId;
+			if (plan.annualStripePriceId && annualUnchanged) {
+				this.logger.warn(
+					`Plano ${plan._id} teve o preço mensal alterado (novo stripePriceId: ${stripePrice.id}), ` +
+						`mas annualStripePriceId (${plan.annualStripePriceId}) não foi atualizado junto. ` +
+						'Verifique manualmente se os preços mensal e anual ainda estão consistentes.'
+				);
+			}
 		}
 
 		plan.name = nextName;
@@ -146,6 +163,8 @@ export class AdminService implements OnModuleInit {
 		plan.currency = nextCurrency;
 		plan.interval = nextInterval as Subscription['interval'];
 		plan.intervalCount = nextIntervalCount;
+		plan.annualPrice = nextAnnualPrice;
+		plan.annualStripePriceId = nextAnnualStripePriceId;
 		if (dto.features) {
 			plan.features = dto.features;
 		}

--- a/src/subscription/dto/create-checkout.dto.spec.ts
+++ b/src/subscription/dto/create-checkout.dto.spec.ts
@@ -1,0 +1,64 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateCheckoutDto } from './create-checkout.dto';
+
+describe('CreateCheckoutDto', () => {
+	const base = {
+		userId: 'user_1',
+		successUrl: 'https://ok',
+		cancelUrl: 'https://cancel',
+	};
+
+	it('accepts a valid payload without billingInterval', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, { ...base });
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('accepts billingInterval "monthly"', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, {
+			...base,
+			billingInterval: 'monthly',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('accepts billingInterval "annual"', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, {
+			...base,
+			billingInterval: 'annual',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('rejects billingInterval with wrong case ("Annual")', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, {
+			...base,
+			billingInterval: 'Annual',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.property === 'billingInterval')).toBe(true);
+	});
+
+	it('rejects billingInterval with wrong value ("yearly")', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, {
+			...base,
+			billingInterval: 'yearly',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.property === 'billingInterval')).toBe(true);
+	});
+
+	it('rejects a missing userId', async () => {
+		const dto = plainToInstance(CreateCheckoutDto, {
+			successUrl: 'https://ok',
+			cancelUrl: 'https://cancel',
+		});
+		const errors = await validate(dto);
+		expect(errors.some((e) => e.property === 'userId')).toBe(true);
+	});
+});

--- a/src/subscription/dto/create-checkout.dto.ts
+++ b/src/subscription/dto/create-checkout.dto.ts
@@ -1,0 +1,29 @@
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateCheckoutDto {
+	@ApiProperty({ description: 'ID do usuário que está assinando' })
+	@IsString()
+	@IsNotEmpty()
+	userId: string;
+
+	@ApiProperty({ description: 'URL de redirecionamento em caso de sucesso' })
+	@IsString()
+	@IsNotEmpty()
+	successUrl: string;
+
+	@ApiProperty({
+		description: 'URL de redirecionamento em caso de cancelamento',
+	})
+	@IsString()
+	@IsNotEmpty()
+	cancelUrl: string;
+
+	@ApiPropertyOptional({
+		description: 'Intervalo de cobrança escolhido (padrão: mensal)',
+		enum: ['monthly', 'annual'],
+	})
+	@IsOptional()
+	@IsIn(['monthly', 'annual'])
+	billingInterval?: 'monthly' | 'annual';
+}

--- a/src/subscription/dto/create-subscription.dto.spec.ts
+++ b/src/subscription/dto/create-subscription.dto.spec.ts
@@ -1,0 +1,39 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateSubscriptionDto } from './create-subscription.dto';
+
+describe('CreateSubscriptionDto', () => {
+	it('accepts annualPrice and annualStripePriceId as optional fields', async () => {
+		const dto = plainToInstance(CreateSubscriptionDto, {
+			name: 'Investidor Pro',
+			price: 49,
+			interval: 'month',
+			annualPrice: 411.6,
+			annualStripePriceId: 'price_annual_123',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('still validates with no annual fields (backward compatible)', async () => {
+		const dto = plainToInstance(CreateSubscriptionDto, {
+			name: 'Investidor Pro',
+			price: 49,
+			interval: 'month',
+		});
+		const errors = await validate(dto);
+		expect(errors).toHaveLength(0);
+	});
+
+	it('rejects a non-numeric annualPrice', async () => {
+		const dto = plainToInstance(CreateSubscriptionDto, {
+			name: 'Investidor Pro',
+			price: 49,
+			interval: 'month',
+			annualPrice: 'not-a-number',
+		});
+		const errors = await validate(dto);
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors.some((e) => e.property === 'annualPrice')).toBe(true);
+	});
+});

--- a/src/subscription/dto/create-subscription.dto.ts
+++ b/src/subscription/dto/create-subscription.dto.ts
@@ -49,6 +49,16 @@ export class CreateSubscriptionDto {
 	@IsString()
 	stripeProductId?: string;
 
+	@ApiPropertyOptional({ description: 'Preço anual da assinatura' })
+	@IsOptional()
+	@IsNumber()
+	annualPrice?: number;
+
+	@ApiPropertyOptional({ description: 'ID do preço anual no Stripe' })
+	@IsOptional()
+	@IsString()
+	annualStripePriceId?: string;
+
 	@ApiPropertyOptional({
 		description: 'Se a assinatura está ativa',
 		default: true,

--- a/src/subscription/dto/index.ts
+++ b/src/subscription/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-subscription.dto';
 export * from './create-user-subscription.dto';
 export * from './update-subscription.dto';
+export * from './create-checkout.dto';

--- a/src/subscription/schema/subscription.model.spec.ts
+++ b/src/subscription/schema/subscription.model.spec.ts
@@ -1,0 +1,31 @@
+import { SubscriptionModel } from './subscription.model';
+
+describe('SubscriptionModel', () => {
+	it('validates a document with annualPrice and annualStripePriceId set', () => {
+		const doc = new SubscriptionModel({
+			name: 'Investidor Pro',
+			price: 49,
+			interval: 'month',
+			stripePriceId: 'price_monthly_123',
+			annualPrice: 411.6,
+			annualStripePriceId: 'price_annual_123',
+		});
+		const error = doc.validateSync();
+		expect(error).toBeUndefined();
+		expect(doc.annualPrice).toBe(411.6);
+		expect(doc.annualStripePriceId).toBe('price_annual_123');
+	});
+
+	it('validates a document with no annual fields set (backward compatible)', () => {
+		const doc = new SubscriptionModel({
+			name: 'Investidor Pro',
+			price: 49,
+			interval: 'month',
+			stripePriceId: 'price_monthly_123',
+		});
+		const error = doc.validateSync();
+		expect(error).toBeUndefined();
+		expect(doc.annualPrice).toBeUndefined();
+		expect(doc.annualStripePriceId).toBeUndefined();
+	});
+});

--- a/src/subscription/schema/subscription.model.ts
+++ b/src/subscription/schema/subscription.model.ts
@@ -9,6 +9,8 @@ export interface Subscription extends Document {
 	intervalCount: number;
 	stripePriceId?: string;
 	stripeProductId?: string;
+	annualPrice?: number;
+	annualStripePriceId?: string;
 	isActive: boolean;
 	features?: string[];
 	maxUsers?: number;
@@ -30,6 +32,8 @@ const subscriptionSchema = new Schema<Subscription>({
 	intervalCount: { type: Number, default: 1, required: true },
 	stripePriceId: { type: String, unique: true, sparse: true },
 	stripeProductId: { type: String, unique: true, sparse: true },
+	annualPrice: { type: Number },
+	annualStripePriceId: { type: String, unique: true, sparse: true },
 	isActive: { type: Boolean, default: true },
 	features: [{ type: String }],
 	maxUsers: { type: Number },

--- a/src/subscription/subscription.controller.spec.ts
+++ b/src/subscription/subscription.controller.spec.ts
@@ -164,7 +164,29 @@ describe('SubscriptionController', () => {
 				body.userId,
 				'sub123',
 				body.successUrl,
-				body.cancelUrl
+				body.cancelUrl,
+				undefined
+			);
+		});
+
+		it('should pass billingInterval through to the service', async () => {
+			const body = {
+				userId: 'user123',
+				successUrl: 'http://success',
+				cancelUrl: 'http://cancel',
+				billingInterval: 'annual' as const,
+			};
+			const result = { sessionId: 'sess_123', url: 'http://stripe.url' };
+
+			mockSubscriptionService.createCheckoutSession.mockResolvedValue(result);
+
+			expect(await controller.createCheckout('sub123', body)).toEqual(result);
+			expect(service.createCheckoutSession).toHaveBeenCalledWith(
+				body.userId,
+				'sub123',
+				body.successUrl,
+				body.cancelUrl,
+				'annual'
 			);
 		});
 	});

--- a/src/subscription/subscription.controller.spec.ts
+++ b/src/subscription/subscription.controller.spec.ts
@@ -1,12 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { SubscriptionController } from './subscription.controller';
 import { SubscriptionService } from './subscription.service';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CreateSubscriptionDto, UpdateSubscriptionDto } from './dto';
 import { WebhooksService } from 'src/subscription/webhooks.service';
 import { StripeService } from 'src/subscription/stripe.service';
 import { IS_PUBLIC_KEY } from 'src/utils/constants';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Role } from 'src/auth/enums/role.enum';
 
 const mockSubscriptionModel = {
 	create: jest.fn(),
@@ -202,5 +205,50 @@ describe('SubscriptionController', () => {
 			);
 			expect(isPublic).toBe(true);
 		});
+	});
+
+	describe('SubscriptionController — plan mutation role protection', () => {
+		const rolesGuard = new RolesGuard(new Reflector());
+
+		const buildContext = (
+			handler: (...args: any[]) => any,
+			role: Role
+		): ExecutionContext =>
+			({
+				getHandler: () => handler,
+				getClass: () => SubscriptionController,
+				switchToHttp: () => ({
+					getRequest: () => ({ user: { userId: 'user-1', role } }),
+				}),
+			}) as unknown as ExecutionContext;
+
+		const protectedHandlers: Array<
+			[string, (...args: any[]) => any]
+		> = [
+			['create', SubscriptionController.prototype.create],
+			['update', SubscriptionController.prototype.update],
+			['updateFeatures', SubscriptionController.prototype.updateFeatures],
+			['remove', SubscriptionController.prototype.remove],
+		];
+
+		it.each(protectedHandlers)(
+			'denies %s to a non-admin authenticated user (403)',
+			(_name, handler) => {
+				const context = buildContext(handler, Role.User);
+
+				expect(() => rolesGuard.canActivate(context)).toThrow(
+					ForbiddenException
+				);
+			}
+		);
+
+		it.each(protectedHandlers)(
+			'allows %s for an admin user',
+			(_name, handler) => {
+				const context = buildContext(handler, Role.Admin);
+
+				expect(rolesGuard.canActivate(context)).toBe(true);
+			}
+		);
 	});
 });

--- a/src/subscription/subscription.controller.spec.ts
+++ b/src/subscription/subscription.controller.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
 import { SubscriptionController } from './subscription.controller';
 import { SubscriptionService } from './subscription.service';
 import { NotFoundException } from '@nestjs/common';
 import { CreateSubscriptionDto, UpdateSubscriptionDto } from './dto';
 import { WebhooksService } from 'src/subscription/webhooks.service';
 import { StripeService } from 'src/subscription/stripe.service';
+import { IS_PUBLIC_KEY } from 'src/utils/constants';
 
 const mockSubscriptionModel = {
 	create: jest.fn(),
@@ -188,6 +190,17 @@ describe('SubscriptionController', () => {
 				body.cancelUrl,
 				'annual'
 			);
+		});
+	});
+
+	describe('SubscriptionController — public routes', () => {
+		it('marks findAll as public (no auth required)', () => {
+			const reflector = new Reflector();
+			const isPublic = reflector.get(
+				IS_PUBLIC_KEY,
+				SubscriptionController.prototype.findAll
+			);
+			expect(isPublic).toBe(true);
 		});
 	});
 });

--- a/src/subscription/subscription.controller.ts
+++ b/src/subscription/subscription.controller.ts
@@ -56,13 +56,20 @@ export class SubscriptionController {
 	@Post(':subscriptionId/checkout')
 	createCheckout(
 		@Param('subscriptionId') subscriptionId: string,
-		@Body() body: { userId: string; successUrl: string; cancelUrl: string }
+		@Body()
+		body: {
+			userId: string;
+			successUrl: string;
+			cancelUrl: string;
+			billingInterval?: 'monthly' | 'annual';
+		}
 	) {
 		return this.subscriptionService.createCheckoutSession(
 			body.userId,
 			subscriptionId,
 			body.successUrl,
-			body.cancelUrl
+			body.cancelUrl,
+			body.billingInterval
 		);
 	}
 

--- a/src/subscription/subscription.controller.ts
+++ b/src/subscription/subscription.controller.ts
@@ -18,6 +18,7 @@ import {
 	ApiResponse,
 	ApiTags,
 } from '@nestjs/swagger';
+import { Public } from 'src/utils/constants';
 
 @Controller('subscription')
 @ApiTags('subscription')
@@ -39,6 +40,7 @@ export class SubscriptionController {
 		};
 	}
 
+	@Public()
 	@Get()
 	@ApiOperation({ summary: 'Listar todos os planos' })
 	findAll() {

--- a/src/subscription/subscription.controller.ts
+++ b/src/subscription/subscription.controller.ts
@@ -7,11 +7,13 @@ import {
 	Param,
 	Delete,
 	Req,
+	UseGuards,
 } from '@nestjs/common';
 import { SubscriptionService } from './subscription.service';
 import { CreateSubscriptionDto } from './dto/create-subscription.dto';
 import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
 import { UpdateFeaturesDto } from './dto/update-features.dto';
+import { CreateCheckoutDto } from './dto/create-checkout.dto';
 import {
 	ApiBearerAuth,
 	ApiOperation,
@@ -19,6 +21,9 @@ import {
 	ApiTags,
 } from '@nestjs/swagger';
 import { Public } from 'src/utils/constants';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Role } from 'src/auth/enums/role.enum';
 
 @Controller('subscription')
 @ApiTags('subscription')
@@ -58,13 +63,7 @@ export class SubscriptionController {
 	@Post(':subscriptionId/checkout')
 	createCheckout(
 		@Param('subscriptionId') subscriptionId: string,
-		@Body()
-		body: {
-			userId: string;
-			successUrl: string;
-			cancelUrl: string;
-			billingInterval?: 'monthly' | 'annual';
-		}
+		@Body() body: CreateCheckoutDto
 	) {
 		return this.subscriptionService.createCheckoutSession(
 			body.userId,
@@ -84,11 +83,15 @@ export class SubscriptionController {
 	}
 
 	@Post('create')
+	@UseGuards(RolesGuard)
+	@Roles(Role.Admin)
 	create(@Body() createSubscriptionDto: CreateSubscriptionDto) {
 		return this.subscriptionService.createSubscription(createSubscriptionDto);
 	}
 
 	@Patch(':id')
+	@UseGuards(RolesGuard)
+	@Roles(Role.Admin)
 	update(
 		@Param('id') id: string,
 		@Body() updateSubscriptionDto: UpdateSubscriptionDto
@@ -100,6 +103,8 @@ export class SubscriptionController {
 	}
 
 	@Patch(':id/features')
+	@UseGuards(RolesGuard)
+	@Roles(Role.Admin)
 	updateFeatures(
 		@Param('id') id: string,
 		@Body() updateFeaturesDto: UpdateFeaturesDto
@@ -116,6 +121,8 @@ export class SubscriptionController {
 	}
 
 	@Delete('delete/:id')
+	@UseGuards(RolesGuard)
+	@Roles(Role.Admin)
 	remove(@Param('id') id: string) {
 		return this.subscriptionService.removeSubscription(id);
 	}

--- a/src/subscription/subscription.service.spec.ts
+++ b/src/subscription/subscription.service.spec.ts
@@ -26,8 +26,8 @@ jest.mock('stripe', () => {
 describe('SubscriptionService', () => {
 	let service: SubscriptionService;
 	let mockSubscriptionModel: any;
-	// let mockUserSubscriptionModel: any;
-	// let mockUserModel: any;
+	let mockUserSubscriptionModel: any;
+	let mockUserModel: any;
 	let mockStripeService: any;
 	let mockWebhooksService: any;
 
@@ -45,8 +45,8 @@ describe('SubscriptionService', () => {
 		});
 
 		mockSubscriptionModel.findById = jest.fn();
-		const mockUserSubscriptionModel = { findOne: jest.fn(), create: jest.fn() };
-		const mockUserModel = { findById: jest.fn() };
+		mockUserSubscriptionModel = { findOne: jest.fn(), create: jest.fn() };
+		mockUserModel = { findById: jest.fn() };
 		mockStripeService = {
 			createProduct: jest.fn().mockResolvedValue({ id: 'prod_123' }),
 			createPrice: jest.fn().mockResolvedValue({ id: 'price_123' }),
@@ -103,6 +103,77 @@ describe('SubscriptionService', () => {
 			const result = await service.checkExpiredSubscriptions();
 			expect(result).toBe('ok');
 			expect(mockWebhooksService.checkExpiredSubscriptions).toHaveBeenCalled();
+		});
+	});
+
+	describe('createCheckoutSession — billing interval', () => {
+		const plan = {
+			_id: 'plan_1',
+			stripePriceId: 'price_monthly_123',
+			annualStripePriceId: 'price_annual_123',
+		};
+
+		beforeEach(() => {
+			mockUserModel.findById.mockResolvedValue({ _id: 'user_1' });
+			mockSubscriptionModel.findById.mockResolvedValue(plan);
+			mockStripeService.createCheckoutSession.mockResolvedValue({
+				url: 'https://checkout.stripe.com/x',
+			});
+		});
+
+		it('uses stripePriceId when billingInterval is monthly (default)', async () => {
+			await service.createCheckoutSession(
+				'user_1',
+				'plan_1',
+				'https://ok',
+				'https://cancel'
+			);
+
+			expect(mockStripeService.createCheckoutSession).toHaveBeenCalledWith(
+				'user_1',
+				'price_monthly_123',
+				'https://ok',
+				'https://cancel'
+			);
+		});
+
+		it('uses annualStripePriceId when billingInterval is annual', async () => {
+			await service.createCheckoutSession(
+				'user_1',
+				'plan_1',
+				'https://ok',
+				'https://cancel',
+				'annual'
+			);
+
+			expect(mockStripeService.createCheckoutSession).toHaveBeenCalledWith(
+				'user_1',
+				'price_annual_123',
+				'https://ok',
+				'https://cancel'
+			);
+		});
+
+		it('falls back to stripePriceId when billingInterval is annual but annualStripePriceId is not configured', async () => {
+			mockSubscriptionModel.findById.mockResolvedValue({
+				...plan,
+				annualStripePriceId: undefined,
+			});
+
+			await service.createCheckoutSession(
+				'user_1',
+				'plan_1',
+				'https://ok',
+				'https://cancel',
+				'annual'
+			);
+
+			expect(mockStripeService.createCheckoutSession).toHaveBeenCalledWith(
+				'user_1',
+				'price_monthly_123',
+				'https://ok',
+				'https://cancel'
+			);
 		});
 	});
 });
@@ -227,7 +298,30 @@ describe('SubscriptionController', () => {
 				body.userId,
 				'sub123',
 				body.successUrl,
-				body.cancelUrl
+				body.cancelUrl,
+				undefined
+			);
+		});
+
+		it('should pass billingInterval through to the service', async () => {
+			const body = {
+				userId: 'user1',
+				successUrl: 'http://success.url',
+				cancelUrl: 'http://cancel.url',
+				billingInterval: 'annual' as const,
+			};
+			const result = { sessionId: 'sess_123' };
+			mockSubscriptionService.createCheckoutSession.mockResolvedValue(result);
+
+			expect(await controller.createCheckout('sub123', body)).toEqual(result);
+			expect(
+				mockSubscriptionService.createCheckoutSession
+			).toHaveBeenCalledWith(
+				body.userId,
+				'sub123',
+				body.successUrl,
+				body.cancelUrl,
+				'annual'
 			);
 		});
 	});

--- a/src/subscription/subscription.service.spec.ts
+++ b/src/subscription/subscription.service.spec.ts
@@ -175,6 +175,30 @@ describe('SubscriptionService', () => {
 				'https://cancel'
 			);
 		});
+
+		it('falls back to stripePriceId and logs a warning when an invalid billingInterval reaches the service directly', async () => {
+			const warnSpy = jest
+				.spyOn((service as any).logger, 'warn')
+				.mockImplementation(() => undefined);
+
+			await service.createCheckoutSession(
+				'user_1',
+				'plan_1',
+				'https://ok',
+				'https://cancel',
+				'yearly' as any
+			);
+
+			expect(mockStripeService.createCheckoutSession).toHaveBeenCalledWith(
+				'user_1',
+				'price_monthly_123',
+				'https://ok',
+				'https://cancel'
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('billingInterval inválido')
+			);
+		});
 	});
 });
 

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -317,7 +317,8 @@ export class SubscriptionService {
 		userId: string,
 		subscriptionId: string,
 		successUrl: string,
-		cancelUrl: string
+		cancelUrl: string,
+		billingInterval: 'monthly' | 'annual' = 'monthly'
 	) {
 		// lógica de negócio
 		const user = await this.userModel.findById(userId);
@@ -326,9 +327,20 @@ export class SubscriptionService {
 		const plan = await this.subscriptionModel.findById(subscriptionId);
 		if (!plan) throw new NotFoundException('Plano não encontrado');
 
+		let priceId = plan.stripePriceId;
+		if (billingInterval === 'annual') {
+			if (plan.annualStripePriceId) {
+				priceId = plan.annualStripePriceId;
+			} else {
+				this.logger.warn(
+					`Plano ${plan._id} não tem annualStripePriceId configurado; usando preço mensal como fallback`
+				);
+			}
+		}
+
 		return this.stripeService.createCheckoutSession(
 			user._id.toString(),
-			plan.stripePriceId,
+			priceId,
 			successUrl,
 			cancelUrl
 		);

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -336,6 +336,10 @@ export class SubscriptionService {
 					`Plano ${plan._id} não tem annualStripePriceId configurado; usando preço mensal como fallback`
 				);
 			}
+		} else if (billingInterval !== 'monthly') {
+			this.logger.warn(
+				`billingInterval inválido recebido ("${billingInterval}") para o plano ${plan._id}; usando preço mensal como fallback`
+			);
 		}
 
 		return this.stripeService.createCheckoutSession(


### PR DESCRIPTION
## Summary
- Adds `annualPrice`/`annualStripePriceId` to the `Subscription` plan schema (one plan, two Stripe prices — mirrors Stripe's own Product/Price model instead of duplicating plans).
- `POST /subscription/:id/checkout` now accepts `billingInterval: 'monthly' | 'annual'` (validated via new `CreateCheckoutDto`) and charges the matching Stripe price, falling back to monthly with a logged warning if the annual price isn't configured yet.
- `GET /subscription` is now public so the landing page can list real plans instead of hardcoded data.
- `AdminService.updatePlan` now persists the annual fields and warns on potential desync when a monthly price regeneration might invalidate an existing `annualStripePriceId`.
- Bundled: `RolesGuard`/`@Roles(Role.Admin)` protection on `create`/`update`/`updateFeatures`/`remove` in `SubscriptionController` (public/read/checkout/portal/cancel routes untouched), using the same pre-existing auth infra as `AdminController`.

## Test plan
- [x] Full server test suite: 495/497 passing (2 pre-existing failures in `ai/ai.controller.spec.ts`, confirmed unrelated — fail identically with this branch's commits stashed out)
- [x] Task-level + final whole-branch review (opus) + scoped re-review, all clean per SDD process
- [ ] Manual (post-merge, requires Stripe dashboard): create real annual Stripe prices per plan, populate `annualStripePriceId` via `PATCH /subscription/:id`, confirm checkout session uses the correct price ID for `billingInterval: 'annual'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)