### PR TITLE
feat(server): add isFeatured and isComingSoon flags to plans

### DIFF
--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -152,4 +152,46 @@ describe('AdminService — updatePlan', () => {
 
 		expect(warnSpy).not.toHaveBeenCalled();
 	});
+
+	it('persists isFeatured and isComingSoon when provided', async () => {
+		const plan = buildPlan({
+			isFeatured: false,
+			isComingSoon: false,
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+
+		await service.updatePlan('plan_1', {
+			isFeatured: true,
+			isComingSoon: true,
+		} as any);
+
+		expect(plan.isFeatured).toBe(true);
+		expect(plan.isComingSoon).toBe(true);
+		expect(plan.save).toHaveBeenCalled();
+	});
+
+	it('leaves isFeatured and isComingSoon untouched when omitted', async () => {
+		const plan = buildPlan({
+			isFeatured: true,
+			isComingSoon: false,
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+
+		await service.updatePlan('plan_1', { description: 'nova descrição' } as any);
+
+		expect(plan.isFeatured).toBe(true);
+		expect(plan.isComingSoon).toBe(false);
+	});
+
+	it('allows clearing isFeatured with an explicit false', async () => {
+		const plan = buildPlan({
+			isFeatured: true,
+			isComingSoon: false,
+		});
+		mockSubscriptionModel.findById.mockResolvedValue(plan);
+
+		await service.updatePlan('plan_1', { isFeatured: false } as any);
+
+		expect(plan.isFeatured).toBe(false);
+	});
 });

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -174,6 +174,12 @@ export class AdminService implements OnModuleInit {
 		if (dto.isActive !== undefined) {
 			plan.isActive = dto.isActive;
 		}
+		if (dto.isFeatured !== undefined) {
+			plan.isFeatured = dto.isFeatured;
+		}
+		if (dto.isComingSoon !== undefined) {
+			plan.isComingSoon = dto.isComingSoon;
+		}
 		await plan.save();
 
 		return plan;

--- a/src/subscription/dto/create-subscription.dto.spec.ts
+++ b/src/subscription/dto/create-subscription.dto.spec.ts
@@ -36,4 +36,31 @@ describe('CreateSubscriptionDto', () => {
 		expect(errors.length).toBeGreaterThan(0);
 		expect(errors.some((e) => e.property === 'annualPrice')).toBe(true);
 	});
+
+	it('accepts isFeatured and isComingSoon as booleans', async () => {
+		const dto = plainToInstance(CreateSubscriptionDto, {
+			name: 'Plano',
+			price: 10,
+			interval: 'month',
+			isFeatured: true,
+			isComingSoon: false,
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors).toHaveLength(0);
+	});
+
+	it('rejects non-boolean isFeatured', async () => {
+		const dto = plainToInstance(CreateSubscriptionDto, {
+			name: 'Plano',
+			price: 10,
+			interval: 'month',
+			isFeatured: 'sim',
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors.some((error) => error.property === 'isFeatured')).toBe(true);
+	});
 });

--- a/src/subscription/dto/create-subscription.dto.ts
+++ b/src/subscription/dto/create-subscription.dto.ts
@@ -67,6 +67,22 @@ export class CreateSubscriptionDto {
 	@IsBoolean()
 	isActive?: boolean;
 
+	@ApiPropertyOptional({
+		description: 'Se o plano deve ser destacado na landing',
+		default: false,
+	})
+	@IsOptional()
+	@IsBoolean()
+	isFeatured?: boolean;
+
+	@ApiPropertyOptional({
+		description: 'Se o plano deve ser exibido como "em breve"',
+		default: false,
+	})
+	@IsOptional()
+	@IsBoolean()
+	isComingSoon?: boolean;
+
 	@ApiPropertyOptional({ description: 'Lista de recursos incluídos' })
 	@IsOptional()
 	@IsArray()

--- a/src/subscription/schema/subscription.model.spec.ts
+++ b/src/subscription/schema/subscription.model.spec.ts
@@ -28,4 +28,32 @@ describe('SubscriptionModel', () => {
 		expect(doc.annualPrice).toBeUndefined();
 		expect(doc.annualStripePriceId).toBeUndefined();
 	});
+
+	it('defaults isFeatured and isComingSoon to false', () => {
+		const doc = new SubscriptionModel({
+			name: 'Plano Teste',
+			price: 10,
+			currency: 'brl',
+			interval: 'month',
+			intervalCount: 1,
+		});
+
+		expect(doc.isFeatured).toBe(false);
+		expect(doc.isComingSoon).toBe(false);
+	});
+
+	it('accepts isFeatured and isComingSoon when provided', () => {
+		const doc = new SubscriptionModel({
+			name: 'Plano Destaque',
+			price: 10,
+			currency: 'brl',
+			interval: 'month',
+			intervalCount: 1,
+			isFeatured: true,
+			isComingSoon: true,
+		});
+
+		expect(doc.isFeatured).toBe(true);
+		expect(doc.isComingSoon).toBe(true);
+	});
 });

--- a/src/subscription/schema/subscription.model.ts
+++ b/src/subscription/schema/subscription.model.ts
@@ -11,6 +11,8 @@ export interface Subscription extends Document {
 	stripeProductId?: string;
 	annualPrice?: number;
 	annualStripePriceId?: string;
+	isFeatured?: boolean;
+	isComingSoon?: boolean;
 	isActive: boolean;
 	features?: string[];
 	maxUsers?: number;
@@ -34,6 +36,8 @@ const subscriptionSchema = new Schema<Subscription>({
 	stripeProductId: { type: String, unique: true, sparse: true },
 	annualPrice: { type: Number },
 	annualStripePriceId: { type: String, unique: true, sparse: true },
+	isFeatured: { type: Boolean, default: false },
+	isComingSoon: { type: Boolean, default: false },
 	isActive: { type: Boolean, default: true },
 	features: [{ type: String }],
 	maxUsers: { type: Number },


### PR DESCRIPTION
## Summary
The frontend identified plans by hardcoded name — `plan.name === 'Investidor Pro'` for the "most chosen" badge, and a substring match on `'globalinvestor'` for the coming-soon state. That broke in production: the real plan in the database is named "Pro", so no plan was ever highlighted.

This adds two optional presentation flags so the frontend can stop guessing:
- `isFeatured` and `isComingSoon` on the `Subscription` schema, both `default: false` — additive, no migration, existing documents keep working.
- Both on `CreateSubscriptionDto` as `@IsOptional() @IsBoolean()`; `UpdateSubscriptionDto` inherits them via `PartialType`.
- `AdminService.updatePlan` persists them, guarded with `!== undefined` so an explicit `false` clears a previously-set flag. `createPlan` is untouched — it already spreads the whole DTO.

The backend deliberately does **not** enforce that at most one plan is featured; that would need a transactional write demoting siblings. The companion web branch highlights only the first marked plan in display order.

## Test plan
- [x] Full suite: 502 passing, 2 pre-existing failures in `ai/ai.controller.spec.ts` (fail on `develop` too)
- [x] `tsc --noEmit` clean
- [x] Task-level reviews + final whole-branch review (opus), all clean
- [x] Verified end-to-end: the global `ValidationPipe` (`whitelist: true`) passes the fields through rather than stripping them; `GET /subscription` serialises them, with Mongoose applying `default: false` on hydration so legacy plans never return `undefined`; a flags-only PATCH does not trigger a Stripe price regeneration

## Deploy notes
1. **Merge and deploy this before the companion web branch.** `forbidNonWhitelisted: true` means that if web ships first, an admin plan save carrying the new fields gets a 400 that rejects the *entire* update.
2. **This does not fix the visible symptom on its own.** Both flags default to `false`, so still no badge appears until someone ticks "Destacar na landing" on a plan in the admin panel. That toggle belongs on the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)