### PR TITLE
fix(server): unbreak lint CI and stop hammering Yahoo Finance when rate limited

### DIFF
--- a/src/market-data/infrastructure/yahoo-finance.adapter.spec.ts
+++ b/src/market-data/infrastructure/yahoo-finance.adapter.spec.ts
@@ -5,6 +5,7 @@ jest.mock('yahoo-finance2', () => ({
 	},
 }));
 
+import { Logger } from '@nestjs/common';
 import yahooFinance from 'yahoo-finance2';
 import { YahooFinanceAdapter } from './yahoo-finance.adapter';
 
@@ -13,6 +14,7 @@ const mockedQuoteSummary = yahooFinance.quoteSummary as jest.Mock;
 describe('YahooFinanceAdapter', () => {
 	beforeEach(() => {
 		mockedQuoteSummary.mockReset();
+		(YahooFinanceAdapter as any).rateLimitedUntil = 0;
 	});
 
 	it('maps a full quoteSummary response to a snapshot, normalizing the B3 ticker', async () => {
@@ -155,5 +157,119 @@ describe('YahooFinanceAdapter', () => {
 				}),
 			})
 		);
+	});
+
+	describe('rate limit handling', () => {
+		let warnSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			warnSpy = jest
+				.spyOn(Logger.prototype, 'warn')
+				.mockImplementation(() => undefined);
+		});
+
+		afterEach(() => {
+			warnSpy.mockRestore();
+		});
+
+		it('triggers a global cooldown when the error exposes a 429 status', async () => {
+			const rateLimitError = Object.assign(new Error('boom'), {
+				response: { status: 429 },
+			});
+			mockedQuoteSummary.mockRejectedValueOnce(rateLimitError);
+
+			const adapter = new YahooFinanceAdapter();
+			const result = await adapter.getSnapshot('RATE1', 'stock');
+
+			expect(result).toBeNull();
+			expect((YahooFinanceAdapter as any).rateLimitedUntil).toBeGreaterThan(
+				Date.now()
+			);
+		});
+
+		it('triggers a global cooldown when the error message says Too Many Requests', async () => {
+			mockedQuoteSummary.mockRejectedValueOnce(new Error('Too Many Requests'));
+
+			const adapter = new YahooFinanceAdapter();
+			const result = await adapter.getSnapshot('RATE2', 'stock');
+
+			expect(result).toBeNull();
+			expect((YahooFinanceAdapter as any).rateLimitedUntil).toBeGreaterThan(
+				Date.now()
+			);
+		});
+
+		it('skips the network call for a different symbol while the cooldown is active', async () => {
+			mockedQuoteSummary.mockRejectedValueOnce(new Error('Too Many Requests'));
+
+			const adapter = new YahooFinanceAdapter();
+			await adapter.getSnapshot('RATE3', 'stock');
+			mockedQuoteSummary.mockClear();
+
+			const second = await adapter.getSnapshot('RATE4', 'stock');
+
+			expect(second).toBeNull();
+			expect(mockedQuoteSummary).not.toHaveBeenCalled();
+		});
+
+		it('still serves a valid positive cache entry during the cooldown', async () => {
+			mockedQuoteSummary.mockResolvedValueOnce({
+				price: { regularMarketPrice: 42, regularMarketChangePercent: 1 },
+				summaryDetail: {},
+				defaultKeyStatistics: {},
+				financialData: {},
+				summaryProfile: {},
+			});
+
+			const adapter = new YahooFinanceAdapter();
+			const cachedResult = await adapter.getSnapshot('RATE5', 'stock');
+			expect(cachedResult?.price).toBe(42);
+
+			mockedQuoteSummary.mockRejectedValueOnce(new Error('Too Many Requests'));
+			await adapter.getSnapshot('RATE6', 'stock');
+			mockedQuoteSummary.mockClear();
+
+			const stillCached = await adapter.getSnapshot('RATE5', 'stock');
+			expect(stillCached?.price).toBe(42);
+			expect(mockedQuoteSummary).not.toHaveBeenCalled();
+		});
+
+		it('does not trigger the cooldown for an ordinary error and only negative-caches that symbol', async () => {
+			mockedQuoteSummary.mockRejectedValueOnce(
+				new Error('Quote not found for ticker symbol: RATE7.SA')
+			);
+
+			const adapter = new YahooFinanceAdapter();
+			const result = await adapter.getSnapshot('RATE7', 'stock');
+
+			expect(result).toBeNull();
+			expect((YahooFinanceAdapter as any).rateLimitedUntil).toBeLessThanOrEqual(
+				Date.now()
+			);
+
+			mockedQuoteSummary.mockResolvedValueOnce({
+				price: { regularMarketPrice: 7, regularMarketChangePercent: 0 },
+				summaryDetail: {},
+				defaultKeyStatistics: {},
+				financialData: {},
+				summaryProfile: {},
+			});
+			const otherSymbol = await adapter.getSnapshot('RATE8', 'stock');
+			expect(otherSymbol?.price).toBe(7);
+		});
+
+		it('logs the rate-limit warning only once while the cooldown is active', async () => {
+			mockedQuoteSummary.mockRejectedValueOnce(new Error('Too Many Requests'));
+
+			const adapter = new YahooFinanceAdapter();
+			await adapter.getSnapshot('RATE9', 'stock');
+			await adapter.getSnapshot('RATE10', 'stock');
+			await adapter.getSnapshot('RATE11', 'stock');
+
+			const rateLimitWarnings = warnSpy.mock.calls.filter((call) =>
+				String(call[0]).includes('rate limit')
+			);
+			expect(rateLimitWarnings).toHaveLength(1);
+		});
 	});
 });

--- a/src/market-data/infrastructure/yahoo-finance.adapter.ts
+++ b/src/market-data/infrastructure/yahoo-finance.adapter.ts
@@ -38,7 +38,9 @@ export class YahooFinanceAdapter {
 	private static readonly CACHE_TTL_MS = 10 * 60 * 1000;
 	private static readonly NEGATIVE_CACHE_TTL_MS = 3 * 60 * 1000;
 	private static readonly FETCH_TIMEOUT_MS = 8000;
+	private static readonly RATE_LIMIT_COOLDOWN_MS = 60 * 1000;
 	private static noticesSuppressed = false;
+	private static rateLimitedUntil = 0;
 
 	constructor() {
 		if (
@@ -61,6 +63,20 @@ export class YahooFinanceAdapter {
 		return typeof value === 'number' && Number.isFinite(value) ? value : null;
 	}
 
+	private isRateLimitError(error: unknown): boolean {
+		if (!error) return false;
+		const err = error as {
+			response?: { status?: number };
+			status?: number;
+			message?: unknown;
+		};
+		const status = err?.response?.status ?? err?.status;
+		if (status === 429) return true;
+		const message =
+			typeof err?.message === 'string' ? err.message : String(error);
+		return /too many requests/i.test(message);
+	}
+
 	async getSnapshot(
 		symbol: string,
 		assetType: MarketAssetType
@@ -68,6 +84,14 @@ export class YahooFinanceAdapter {
 		const yahooSymbol = normalizeTickerForProvider(symbol, 'yahoo', assetType);
 		const now = Date.now();
 		const cached = YahooFinanceAdapter.cache.get(yahooSymbol);
+		if (cached && cached.expiresAt > now && cached.data !== null) {
+			return cached.data;
+		}
+
+		if (YahooFinanceAdapter.rateLimitedUntil > now) {
+			return null;
+		}
+
 		if (cached && cached.expiresAt > now) return cached.data;
 
 		const existingRequest = YahooFinanceAdapter.inflight.get(yahooSymbol);
@@ -127,6 +151,19 @@ export class YahooFinanceAdapter {
 			});
 			return snapshot;
 		} catch (error) {
+			if (this.isRateLimitError(error)) {
+				const now = Date.now();
+				const alreadyRateLimited = YahooFinanceAdapter.rateLimitedUntil > now;
+				YahooFinanceAdapter.rateLimitedUntil =
+					now + YahooFinanceAdapter.RATE_LIMIT_COOLDOWN_MS;
+				if (!alreadyRateLimited) {
+					this.logger.warn(
+						`Yahoo Finance retornou rate limit (429). Pausando consultas por ${YahooFinanceAdapter.RATE_LIMIT_COOLDOWN_MS / 1000}s.`
+					);
+				}
+				return null;
+			}
+
 			this.logger.warn(
 				`Falha ao consultar Yahoo Finance para ${yahooSymbol}: ${error?.message || error}`
 			);

--- a/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.spec.ts
@@ -694,19 +694,21 @@ describe('RiDocumentCatalogService', () => {
 describe('RiDocumentCatalogService — origin resolution', () => {
 	it('uses the Google CSE fallback origin for a company outside the known list, instead of guessing a slug', async () => {
 		const originSearch = {
-			searchOfficialOrigin: jest.fn().mockResolvedValue('https://ri.empresa-real.com.br'),
+			searchOfficialOrigin: jest
+				.fn()
+				.mockResolvedValue('https://ri.empresa-real.com.br'),
 		};
 		const documentDiscovery = {
 			discover: jest.fn().mockResolvedValue([]),
 		};
 		const assetAutocomplete = {
-			search: jest.fn().mockResolvedValue([
-				{ ticker: 'ABCD3', company: 'Empresa Real S.A.' },
-			]),
+			search: jest
+				.fn()
+				.mockResolvedValue([{ ticker: 'ABCD3', company: 'Empresa Real S.A.' }]),
 		};
 		const linkResolver = { resolve: jest.fn() };
 
-		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+		const service = new RiDocumentCatalogService(
 			assetAutocomplete,
 			documentDiscovery,
 			linkResolver,
@@ -715,7 +717,9 @@ describe('RiDocumentCatalogService — origin resolution', () => {
 
 		await service.search({ query: 'ABCD3', limit: 10 });
 
-		expect(originSearch.searchOfficialOrigin).toHaveBeenCalledWith('Empresa Real S.A.');
+		expect(originSearch.searchOfficialOrigin).toHaveBeenCalledWith(
+			'Empresa Real S.A.'
+		);
 		expect(documentDiscovery.discover).toHaveBeenCalledWith(
 			expect.objectContaining({ origin: 'https://ri.empresa-real.com.br' })
 		);
@@ -725,11 +729,13 @@ describe('RiDocumentCatalogService — origin resolution', () => {
 		const originSearch = { searchOfficialOrigin: jest.fn() };
 		const documentDiscovery = { discover: jest.fn().mockResolvedValue([]) };
 		const assetAutocomplete = {
-			search: jest.fn().mockResolvedValue([{ ticker: 'PETR4', company: 'Petrobras' }]),
+			search: jest
+				.fn()
+				.mockResolvedValue([{ ticker: 'PETR4', company: 'Petrobras' }]),
 		};
 		const linkResolver = { resolve: jest.fn() };
 
-		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+		const service = new RiDocumentCatalogService(
 			assetAutocomplete,
 			documentDiscovery,
 			linkResolver,
@@ -745,14 +751,18 @@ describe('RiDocumentCatalogService — origin resolution', () => {
 	});
 
 	it('passes a null origin (not a guessed slug URL) when Google CSE also finds nothing', async () => {
-		const originSearch = { searchOfficialOrigin: jest.fn().mockResolvedValue(null) };
+		const originSearch = {
+			searchOfficialOrigin: jest.fn().mockResolvedValue(null),
+		};
 		const documentDiscovery = { discover: jest.fn().mockResolvedValue([]) };
 		const assetAutocomplete = {
-			search: jest.fn().mockResolvedValue([{ ticker: 'XYZW4', company: 'Empresa Obscura' }]),
+			search: jest
+				.fn()
+				.mockResolvedValue([{ ticker: 'XYZW4', company: 'Empresa Obscura' }]),
 		};
 		const linkResolver = { resolve: jest.fn() };
 
-		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+		const service = new RiDocumentCatalogService(
 			assetAutocomplete,
 			documentDiscovery,
 			linkResolver,
@@ -827,7 +837,7 @@ describe('RiDocumentCatalogService — origin resolution', () => {
 			}),
 		};
 
-		const service = new (require('./ri-document-catalog.service').RiDocumentCatalogService)(
+		const service = new RiDocumentCatalogService(
 			assetAutocomplete,
 			documentDiscovery,
 			linkResolver,

--- a/src/ri-intelligence/application/ri-document-catalog.service.ts
+++ b/src/ri-intelligence/application/ri-document-catalog.service.ts
@@ -444,7 +444,9 @@ export class RiDocumentCatalogService {
 		}
 	}
 
-	private async resolveOrigin(match: RiAssetSuggestion): Promise<string | null> {
+	private async resolveOrigin(
+		match: RiAssetSuggestion
+	): Promise<string | null> {
 		const knownOrigins: Record<string, string> = {
 			BBDC4: 'https://ri.bradesco.com.br',
 			ITUB4: 'https://www.itau.com.br/relacoes-com-investidores',

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.spec.ts
@@ -9,7 +9,12 @@ import { B3RegistryCnpjResolverAdapter } from './b3-registry-cnpj-resolver.adapt
 function singlePageResponse(rows: any[]) {
 	return {
 		data: {
-			page: { pageNumber: 1, pageSize: 120, totalRecords: rows.length, totalPages: 1 },
+			page: {
+				pageNumber: 1,
+				pageSize: 120,
+				totalRecords: rows.length,
+				totalPages: 1,
+			},
 			results: rows,
 		},
 	};
@@ -36,7 +41,10 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 			)
 		);
 		const result = await adapter.resolveCnpj('ABCD3');
-		expect(result).toEqual({ cnpj: '03987364000103', company: 'Empresa Real S.A.' });
+		expect(result).toEqual({
+			cnpj: '03987364000103',
+			company: 'Empresa Real S.A.',
+		});
 	});
 
 	it('returns null when the ticker is not found in the registry', async () => {
@@ -53,7 +61,9 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 		// (StocksRiIssuerCatalogAdapter) não confunda essa falha transitória
 		// com "ticker genuinamente ausente do registro B3" e não poluir o
 		// cache negativo de 6h com uma falha de rede.
-		const adapter = buildAdapter(() => throwError(() => new Error('network down')));
+		const adapter = buildAdapter(() =>
+			throwError(() => new Error('network down'))
+		);
 		await expect(adapter.resolveCnpj('ABCD3')).rejects.toThrow('network down');
 	});
 
@@ -135,7 +145,12 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 			data: {
 				page: { pageNumber: 1, pageSize: 120, totalRecords: 2, totalPages: 2 },
 				results: [
-					{ codeCVM: '1', issuingCompany: 'AAAA', companyName: 'A Co', cnpj: '11111111000111' },
+					{
+						codeCVM: '1',
+						issuingCompany: 'AAAA',
+						companyName: 'A Co',
+						cnpj: '11111111000111',
+					},
 				],
 			},
 		};
@@ -143,11 +158,19 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 			data: {
 				page: { pageNumber: 2, pageSize: 120, totalRecords: 2, totalPages: 2 },
 				results: [
-					{ codeCVM: '2', issuingCompany: 'BBBB', companyName: 'B Co', cnpj: '22222222000122' },
+					{
+						codeCVM: '2',
+						issuingCompany: 'BBBB',
+						companyName: 'B Co',
+						cnpj: '22222222000122',
+					},
 				],
 			},
 		};
-		const getMock = jest.fn().mockReturnValueOnce(of(page1)).mockReturnValueOnce(of(page2));
+		const getMock = jest
+			.fn()
+			.mockReturnValueOnce(of(page1))
+			.mockReturnValueOnce(of(page2));
 		const adapter = buildAdapter(getMock);
 
 		const result = await adapter.resolveCnpj('BBBB3');
@@ -160,8 +183,18 @@ describe('B3RegistryCnpjResolverAdapter', () => {
 		const adapter = buildAdapter(() =>
 			of(
 				singlePageResponse([
-					{ codeCVM: '1', issuingCompany: 'CCCC', companyName: 'C Co', cnpj: '0' },
-					{ codeCVM: '2', issuingCompany: 'DDDD', companyName: '', cnpj: '33333333000133' },
+					{
+						codeCVM: '1',
+						issuingCompany: 'CCCC',
+						companyName: 'C Co',
+						cnpj: '0',
+					},
+					{
+						codeCVM: '2',
+						issuingCompany: 'DDDD',
+						companyName: '',
+						cnpj: '33333333000133',
+					},
 				])
 			)
 		);

--- a/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
+++ b/src/ri-intelligence/infrastructure/b3-registry-cnpj-resolver.adapter.ts
@@ -56,8 +56,10 @@ export class B3RegistryCnpjResolverAdapter {
 	// companhias, ou seja, ~30 páginas de 120.
 	private readonly maxPages = 60;
 
-	private cache: { expiresAt: number; byTicker: Map<string, RegistryEntry> } | null =
-		null;
+	private cache: {
+		expiresAt: number;
+		byTicker: Map<string, RegistryEntry>;
+	} | null = null;
 	private inflight: Promise<Map<string, RegistryEntry>> | null = null;
 	private readonly ttlMs = 24 * 60 * 60 * 1000;
 
@@ -108,16 +110,16 @@ export class B3RegistryCnpjResolverAdapter {
 				const first = await this.fetchPage(1);
 				this.mergeRows(byBaseCode, first.results);
 
-				const totalPages = Math.min(
-					first.page?.totalPages || 1,
-					this.maxPages
-				);
+				const totalPages = Math.min(first.page?.totalPages || 1, this.maxPages);
 				for (let page = 2; page <= totalPages; page++) {
 					const next = await this.fetchPage(page);
 					this.mergeRows(byBaseCode, next.results);
 				}
 
-				this.cache = { expiresAt: Date.now() + this.ttlMs, byTicker: byBaseCode };
+				this.cache = {
+					expiresAt: Date.now() + this.ttlMs,
+					byTicker: byBaseCode,
+				};
 				return byBaseCode;
 			} catch (error) {
 				this.logger.warn(
@@ -158,7 +160,9 @@ export class B3RegistryCnpjResolverAdapter {
 	async resolveCnpj(
 		ticker: string
 	): Promise<{ cnpj: string; company: string } | null> {
-		const normalizedTicker = String(ticker || '').trim().toUpperCase();
+		const normalizedTicker = String(ticker || '')
+			.trim()
+			.toUpperCase();
 		if (!normalizedTicker) return null;
 		const registry = await this.loadRegistry();
 		const entry = registry.get(this.baseCode(normalizedTicker));

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.spec.ts
@@ -3,7 +3,11 @@ import { of, throwError } from 'rxjs';
 import { GoogleCseRiOriginSearchAdapter } from './google-cse-ri-origin-search.adapter';
 
 describe('GoogleCseRiOriginSearchAdapter', () => {
-	function buildAdapter(getImpl: () => any, apiKey = 'key', engineId = 'engine') {
+	function buildAdapter(
+		getImpl: () => any,
+		apiKey = 'key',
+		engineId = 'engine'
+	) {
 		const httpService = { get: jest.fn(getImpl) } as unknown as HttpService;
 		return new GoogleCseRiOriginSearchAdapter(httpService, apiKey, engineId);
 	}
@@ -27,13 +31,19 @@ describe('GoogleCseRiOriginSearchAdapter', () => {
 	});
 
 	it('returns null and does not throw when the request fails', async () => {
-		const adapter = buildAdapter(() => throwError(() => new Error('quota exceeded')));
+		const adapter = buildAdapter(() =>
+			throwError(() => new Error('quota exceeded'))
+		);
 		await expect(adapter.searchOfficialOrigin('Empresa X')).resolves.toBeNull();
 	});
 
 	it('returns null immediately without a request when credentials are missing', async () => {
 		const httpService = { get: jest.fn() } as unknown as HttpService;
-		const adapter = new GoogleCseRiOriginSearchAdapter(httpService, undefined, undefined);
+		const adapter = new GoogleCseRiOriginSearchAdapter(
+			httpService,
+			undefined,
+			undefined
+		);
 		const result = await adapter.searchOfficialOrigin('Empresa Y');
 		expect(result).toBeNull();
 		expect(httpService.get).not.toHaveBeenCalled();

--- a/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
+++ b/src/ri-intelligence/infrastructure/google-cse-ri-origin-search.adapter.ts
@@ -39,13 +39,17 @@ const DENYLISTED_ORIGIN_HOSTS: ReadonlySet<string> = new Set([
 @Injectable()
 export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 	private readonly logger = new Logger(GoogleCseRiOriginSearchAdapter.name);
-	private readonly cache = new Map<string, { expiresAt: number; origin: string | null }>();
+	private readonly cache = new Map<
+		string,
+		{ expiresAt: number; origin: string | null }
+	>();
 	private readonly ttlMs = 24 * 60 * 60 * 1000;
 
 	private isDenylistedHost(hostname: string): boolean {
 		const normalized = hostname.toLowerCase();
 		for (const denied of DENYLISTED_ORIGIN_HOSTS) {
-			if (normalized === denied || normalized.endsWith(`.${denied}`)) return true;
+			if (normalized === denied || normalized.endsWith(`.${denied}`))
+				return true;
 		}
 		return false;
 	}
@@ -53,7 +57,8 @@ export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 	constructor(
 		private readonly httpService: HttpService,
 		@Optional() private readonly apiKey: string | undefined = googleCseApiKey,
-		@Optional() private readonly engineId: string | undefined = googleCseEngineId
+		@Optional()
+		private readonly engineId: string | undefined = googleCseEngineId
 	) {}
 
 	async searchOfficialOrigin(companyName: string): Promise<string | null> {
@@ -86,7 +91,10 @@ export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 			);
 			const firstLink: string | undefined = response.data?.items?.[0]?.link;
 			if (!firstLink) {
-				this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin: null });
+				this.cache.set(normalizedName, {
+					expiresAt: now + this.ttlMs,
+					origin: null,
+				});
 				return null;
 			}
 			const url = new URL(firstLink);
@@ -94,7 +102,10 @@ export class GoogleCseRiOriginSearchAdapter implements RiOriginSearchPort {
 				this.logger.debug(
 					`Top resultado do CSE para "${normalizedName}" é um agregador conhecido (${url.hostname}); tratando como não encontrado`
 				);
-				this.cache.set(normalizedName, { expiresAt: now + this.ttlMs, origin: null });
+				this.cache.set(normalizedName, {
+					expiresAt: now + this.ttlMs,
+					origin: null,
+				});
 				return null;
 			}
 			const origin = `${url.protocol}//${url.host}`;

--- a/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.spec.ts
@@ -176,19 +176,17 @@ describe('ResilientRiDocumentDiscoveryAdapter', () => {
 });
 
 describe('ResilientRiDocumentDiscoveryAdapter — in-memory catalog', () => {
-	function buildAdapter(overrides: {
-		inMemoryDocs?: any[];
-		httpDocs?: any[];
-	}) {
+	function buildAdapter(overrides: { inMemoryDocs?: any[]; httpDocs?: any[] }) {
 		const inMemoryAdapter = {
 			discover: jest.fn().mockResolvedValue(overrides.inMemoryDocs || []),
 		};
-		const httpAdapter = { discover: jest.fn().mockResolvedValue(overrides.httpDocs || []) };
+		const httpAdapter = {
+			discover: jest.fn().mockResolvedValue(overrides.httpDocs || []),
+		};
 		const cvmAdapter = { discover: jest.fn().mockResolvedValue([]) };
 		const fiiAdapter = { discover: jest.fn().mockResolvedValue([]) };
 		const fallbackAdapter = { discover: jest.fn().mockResolvedValue([]) };
 
-		const { ResilientRiDocumentDiscoveryAdapter } = require('./resilient-ri-document-discovery.adapter');
 		const adapter = new ResilientRiDocumentDiscoveryAdapter(
 			inMemoryAdapter,
 			httpAdapter,
@@ -202,11 +200,29 @@ describe('ResilientRiDocumentDiscoveryAdapter — in-memory catalog', () => {
 
 	it('includes in-memory catalog documents alongside http/cvm results for a known ticker', async () => {
 		const { adapter } = buildAdapter({
-			inMemoryDocs: [{ ticker: 'PETR4', documentType: 'earnings_release', title: 'In-memory doc', source: { value: 'x' } }],
-			httpDocs: [{ ticker: 'PETR4', documentType: 'material_fact', title: 'Http doc', source: { value: 'y' } }],
+			inMemoryDocs: [
+				{
+					ticker: 'PETR4',
+					documentType: 'earnings_release',
+					title: 'In-memory doc',
+					source: { value: 'x' },
+				},
+			],
+			httpDocs: [
+				{
+					ticker: 'PETR4',
+					documentType: 'material_fact',
+					title: 'Http doc',
+					source: { value: 'y' },
+				},
+			],
 		});
 
-		const result = await adapter.discover({ ticker: 'PETR4', company: 'Petrobras', origin: 'https://petrobras.com.br/ri' });
+		const result = await adapter.discover({
+			ticker: 'PETR4',
+			company: 'Petrobras',
+			origin: 'https://petrobras.com.br/ri',
+		});
 
 		expect(result.map((d: any) => d.title)).toEqual(
 			expect.arrayContaining(['In-memory doc', 'Http doc'])
@@ -216,10 +232,21 @@ describe('ResilientRiDocumentDiscoveryAdapter — in-memory catalog', () => {
 	it('still returns http/cvm documents for a ticker with no in-memory catalog entry', async () => {
 		const { adapter, inMemoryAdapter, httpAdapter } = buildAdapter({
 			inMemoryDocs: [],
-			httpDocs: [{ ticker: 'ABCD3', documentType: 'material_fact', title: 'Http doc', source: { value: 'y' } }],
+			httpDocs: [
+				{
+					ticker: 'ABCD3',
+					documentType: 'material_fact',
+					title: 'Http doc',
+					source: { value: 'y' },
+				},
+			],
 		});
 
-		const result = await adapter.discover({ ticker: 'ABCD3', company: 'Empresa', origin: 'https://ri.empresa.com.br' });
+		const result = await adapter.discover({
+			ticker: 'ABCD3',
+			company: 'Empresa',
+			origin: 'https://ri.empresa.com.br',
+		});
 
 		expect(inMemoryAdapter.discover).toHaveBeenCalled();
 		expect(httpAdapter.discover).toHaveBeenCalled();

--- a/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.ts
+++ b/src/ri-intelligence/infrastructure/resilient-ri-document-discovery.adapter.ts
@@ -27,7 +27,10 @@ export class ResilientRiDocumentDiscoveryAdapter implements RiDocumentDiscoveryP
 		// paralelo com o restante da cadeia para não somar latência, mas usando o
 		// mesmo guard de timeout — um adapter travado não bloqueia a resposta além
 		// de providerTimeoutMs.
-		const inMemoryDocsPromise = this.safeDiscoverWithTimeout(this.inMemoryAdapter, input);
+		const inMemoryDocsPromise = this.safeDiscoverWithTimeout(
+			this.inMemoryAdapter,
+			input
+		);
 
 		// Primário: para FIIs, o adapter específico de FII; para ações, o adapter
 		// HTTP (bate RI sites estáticos, mais rápido que Puppeteer). O CVM fica

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.spec.ts
@@ -22,7 +22,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 				},
 			],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService,
+			makeB3Registry()
+		);
 
 		const ref = await adapter.resolveByTicker('petr4');
 
@@ -46,7 +49,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 				},
 			],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService,
+			makeB3Registry()
+		);
 
 		const ref = await adapter.resolveByTicker('vale3.SA');
 
@@ -61,7 +67,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		const stockService = makeStockService({
 			results: [{ symbol: 'XXXX3', longName: 'Sem CNPJ SA' }],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService,
+			makeB3Registry()
+		);
 
 		const ref = await adapter.resolveByTicker('XXXX3');
 
@@ -72,7 +81,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		const stockService = {
 			getNationalQuote: jest.fn().mockRejectedValue(new Error('brapi down')),
 		} as unknown as StockService;
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService,
+			makeB3Registry()
+		);
 
 		const ref = await adapter.resolveByTicker('ITUB4');
 
@@ -83,7 +95,10 @@ describe('StocksRiIssuerCatalogAdapter', () => {
 		const stockService = makeStockService({
 			results: [{ symbol: 'ITUB4', cnpj: '60.872.504/0001-23' }],
 		});
-		const adapter = new StocksRiIssuerCatalogAdapter(stockService, makeB3Registry());
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService,
+			makeB3Registry()
+		);
 
 		const [a, b] = await Promise.all([
 			adapter.resolveByTicker('ITUB4'),
@@ -110,9 +125,9 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 				company: 'Empresa Real S.A.',
 			}),
 		};
-		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
-			stockService,
-			b3Registry
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService as unknown as StockService,
+			b3Registry as any
 		);
 
 		const result = await adapter.resolveByTicker('ABCD3');
@@ -128,13 +143,19 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 	it('does not call the B3 registry when Brapi already has a cnpj', async () => {
 		const stockService = {
 			getNationalQuote: jest.fn().mockResolvedValue({
-				results: [{ symbol: 'PETR4', cnpj: '33.000.167/0001-01', longName: 'Petrobras' }],
+				results: [
+					{
+						symbol: 'PETR4',
+						cnpj: '33.000.167/0001-01',
+						longName: 'Petrobras',
+					},
+				],
 			}),
 		};
 		const b3Registry = { resolveCnpj: jest.fn() };
-		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
-			stockService,
-			b3Registry
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService as unknown as StockService,
+			b3Registry as any
 		);
 
 		await adapter.resolveByTicker('PETR4');
@@ -149,9 +170,9 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 			}),
 		};
 		const b3Registry = { resolveCnpj: jest.fn().mockResolvedValue(null) };
-		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
-			stockService,
-			b3Registry
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService as unknown as StockService,
+			b3Registry as any
 		);
 
 		const result = await adapter.resolveByTicker('ZZZZ9');
@@ -174,9 +195,9 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 					company: 'Empresa Recuperada S.A.',
 				}),
 		};
-		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
-			stockService,
-			b3Registry
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService as unknown as StockService,
+			b3Registry as any
 		);
 
 		const first = await adapter.resolveByTicker('WXYZ3');
@@ -202,9 +223,9 @@ describe('StocksRiIssuerCatalogAdapter — B3 registry fallback', () => {
 			}),
 		};
 		const b3Registry = { resolveCnpj: jest.fn().mockResolvedValue(null) };
-		const adapter = new (require('./stocks-ri-issuer-catalog.adapter').StocksRiIssuerCatalogAdapter)(
-			stockService,
-			b3Registry
+		const adapter = new StocksRiIssuerCatalogAdapter(
+			stockService as unknown as StockService,
+			b3Registry as any
 		);
 
 		const first = await adapter.resolveByTicker('NOPE3');

--- a/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
+++ b/src/ri-intelligence/infrastructure/stocks-ri-issuer-catalog.adapter.ts
@@ -60,9 +60,8 @@ export class StocksRiIssuerCatalogAdapter implements RiIssuerCatalogPort {
 				let b3RegistryFailed = false;
 				if (!cnpj) {
 					try {
-						const registryMatch = await this.b3Registry.resolveCnpj(
-							normalizedTicker
-						);
+						const registryMatch =
+							await this.b3Registry.resolveCnpj(normalizedTicker);
 						if (registryMatch) {
 							cnpj = registryMatch.cnpj;
 							company = registryMatch.company || company;

--- a/src/subscription/subscription.controller.spec.ts
+++ b/src/subscription/subscription.controller.spec.ts
@@ -222,9 +222,7 @@ describe('SubscriptionController', () => {
 				}),
 			}) as unknown as ExecutionContext;
 
-		const protectedHandlers: Array<
-			[string, (...args: any[]) => any]
-		> = [
+		const protectedHandlers: Array<[string, (...args: any[]) => any]> = [
 			['create', SubscriptionController.prototype.create],
 			['update', SubscriptionController.prototype.update],
 			['updateFeatures', SubscriptionController.prototype.updateFeatures],


### PR DESCRIPTION
## Summary

Two fixes, both for problems that were live on `develop`.

### 1. Lint CI was red — and the lint rule was right

`bun run lint` failed with 10 `@typescript-eslint/no-var-requires` errors across three RI-intelligence spec files, which used `new (require('./module').Class)(...)` even though every one of those classes was already imported at the top of the same file.

The `require()` wasn't a style slip — it was load-bearing. It bypassed TypeScript entirely, which let inline partial mocks through that never satisfied the real constructor signatures. Removing it exposed exactly that:

```
error TS2345: Argument of type '{ getNationalQuote: jest.Mock }' is not assignable to
parameter of type 'StockService'. Missing: logger, brapi, twelveData, fundamentusFallback,
and 11 more.
```

Fixed by casting the mocks the same way the helper functions at the top of those files already do. **Two suites (10 tests) had been failing to compile and therefore silently never ran** — they now execute and pass. RI-intelligence goes from 92 to 102 tests.

### 2. A Yahoo Finance 429 poisoned every other symbol

Observed in production:

```
WARN [YahooFinanceAdapter] Falha ao consultar Yahoo Finance para BTC-USD:
Unexpected token 'T', "Too Many Requests" is not valid JSON
```

Yahoo answered HTTP 429 with a plain-text body; `yahoo-finance2` tried to parse it as JSON and threw. The adapter treated that like any other failure — a confusing log line, and a 3-minute negative cache **for that one symbol**.

But a 429 is a global limit on the caller, not a fact about `BTC-USD`. So while one symbol sat in its negative cache, every other symbol kept firing at an API already refusing traffic — sustaining the rate limit and burying the logs in misleading JSON-parse noise.

Now a rate-limit response (429 status, or a "Too Many Requests" body) sets a 60-second global cooldown during which no Yahoo call is made at all, logged once per window rather than once per symbol. Valid cached data is still served during the cooldown, since it isn't affected by the limit. Ordinary failures keep their existing per-symbol warning and negative cache untouched.

## Test plan
- [x] `bun run lint` exits 0
- [x] RI-intelligence: 102/102 passing (was 92, with 10 uncompilable)
- [x] Yahoo Finance adapter: 13/13 passing, covering both rate-limit detection shapes, the cross-symbol skip, positive-cache-survives-cooldown, ordinary-error-does-not-trigger-cooldown, and the log-once behaviour
- [x] Full suite: 501/503, the 2 known pre-existing `ai/ai.controller.spec.ts` failures (also red on `develop`)

Formatting changes in the diff come from the lint script itself, which runs `eslint --fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)