### PR TITLE
fix(server): resolve purchase-intent plan from the database and attribute leads

### DIFF
--- a/src/leads/dto/purchase-intent.dto.spec.ts
+++ b/src/leads/dto/purchase-intent.dto.spec.ts
@@ -3,61 +3,73 @@ import { plainToInstance } from 'class-transformer';
 import { PurchaseIntentDto } from './purchase-intent.dto';
 
 describe('PurchaseIntentDto', () => {
-	it('passes validation with a valid email and plan name', async () => {
-		const dto = plainToInstance(PurchaseIntentDto, {
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-		const errors = await validate(dto);
-		expect(errors).toHaveLength(0);
-	});
-
 	it('fails validation with an invalid email', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'not-an-email',
-			planName: 'Premium',
+			planId: '6995af0198591333bb0d4862',
 		});
 		const errors = await validate(dto);
 		expect(errors.length).toBeGreaterThan(0);
 		expect(errors[0].property).toBe('email');
 	});
 
-	it('fails validation with an empty plan name', async () => {
+	it('accepts a valid mongo id and no utm fields', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'investidor@example.com',
-			planName: '',
+			planId: '6995af0198591333bb0d4862',
 		});
-		const errors = await validate(dto);
-		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0].property).toBe('planName');
-	});
 
-	it('passes validation with the other whitelisted plan name', async () => {
-		const dto = plainToInstance(PurchaseIntentDto, {
-			email: 'investidor@example.com',
-			planName: 'Global Investor',
-		});
 		const errors = await validate(dto);
+
 		expect(errors).toHaveLength(0);
 	});
 
-	it('fails validation with a plan name outside the whitelist', async () => {
+	it('rejects a planId that is not a mongo id', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'investidor@example.com',
-			planName: 'NotARealPlan',
+			planId: 'Premium',
 		});
+
 		const errors = await validate(dto);
-		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0].property).toBe('planName');
+
+		expect(errors.some((error) => error.property === 'planId')).toBe(true);
 	});
 
-	it('fails validation when plan name contains HTML/script injection attempts', async () => {
+	it('accepts utm fields within the allowed charset', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'investidor@example.com',
-			planName: '<script>alert(1)</script>',
+			planId: '6995af0198591333bb0d4862',
+			utmSource: 'reddit',
+			utmMedium: 'social-organic',
+			utmCampaign: 'validacao_2026.08',
 		});
+
 		const errors = await validate(dto);
-		expect(errors.length).toBeGreaterThan(0);
-		expect(errors[0].property).toBe('planName');
+
+		expect(errors).toHaveLength(0);
+	});
+
+	it('rejects a utm value with characters outside the allowed charset', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+			utmSource: '<script>alert(1)</script>',
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors.some((error) => error.property === 'utmSource')).toBe(true);
+	});
+
+	it('rejects a utm value longer than 64 characters', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+			utmCampaign: 'a'.repeat(65),
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors.some((error) => error.property === 'utmCampaign')).toBe(true);
 	});
 });

--- a/src/leads/dto/purchase-intent.dto.spec.ts
+++ b/src/leads/dto/purchase-intent.dto.spec.ts
@@ -49,7 +49,7 @@ describe('PurchaseIntentDto', () => {
 		expect(errors).toHaveLength(0);
 	});
 
-	it('rejects a utm value with characters outside the allowed charset', async () => {
+	it('strips a utm value with characters outside the allowed charset instead of rejecting', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'investidor@example.com',
 			planId: '6995af0198591333bb0d4862',
@@ -58,10 +58,11 @@ describe('PurchaseIntentDto', () => {
 
 		const errors = await validate(dto);
 
-		expect(errors.some((error) => error.property === 'utmSource')).toBe(true);
+		expect(errors).toHaveLength(0);
+		expect(dto.utmSource).toBeUndefined();
 	});
 
-	it('rejects a utm value longer than 64 characters', async () => {
+	it('strips a utm value longer than 64 characters instead of rejecting', async () => {
 		const dto = plainToInstance(PurchaseIntentDto, {
 			email: 'investidor@example.com',
 			planId: '6995af0198591333bb0d4862',
@@ -70,6 +71,33 @@ describe('PurchaseIntentDto', () => {
 
 		const errors = await validate(dto);
 
-		expect(errors.some((error) => error.property === 'utmCampaign')).toBe(true);
+		expect(errors).toHaveLength(0);
+		expect(dto.utmCampaign).toBeUndefined();
+	});
+
+	it('strips a utm value containing a space instead of rejecting', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+			utmCampaign: 'Anúncio Julho',
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors).toHaveLength(0);
+		expect(dto.utmCampaign).toBeUndefined();
+	});
+
+	it('strips a utm value with accented characters instead of rejecting', async () => {
+		const dto = plainToInstance(PurchaseIntentDto, {
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+			utmCampaign: 'validação_agosto',
+		});
+
+		const errors = await validate(dto);
+
+		expect(errors).toHaveLength(0);
+		expect(dto.utmCampaign).toBeUndefined();
 	});
 });

--- a/src/leads/dto/purchase-intent.dto.ts
+++ b/src/leads/dto/purchase-intent.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
 	IsEmail,
 	IsMongoId,
@@ -11,6 +12,18 @@ import {
 const UTM_PATTERN = /^[\w.-]+$/;
 const UTM_MESSAGE =
 	'Use apenas letras, números, ponto, hífen ou underscore (máx. 64)';
+
+// Um UTM inválido não deve derrubar a captura do lead: com
+// forbidNonWhitelisted, um erro de validação rejeita a requisição inteira.
+// Em vez disso, descartamos o valor inválido (vira undefined) e deixamos o
+// lead ser registrado sem atribuição. Perder a origem é aceitável; perder o
+// lead não.
+function sanitizeUtmValue({ value }: { value: unknown }): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	if (value.length > 64) return undefined;
+	if (!UTM_PATTERN.test(value)) return undefined;
+	return value;
+}
 
 export class PurchaseIntentDto {
 	@ApiProperty({
@@ -29,6 +42,7 @@ export class PurchaseIntentDto {
 
 	@ApiPropertyOptional({ description: 'Origem da campanha (utm_source)' })
 	@IsOptional()
+	@Transform(sanitizeUtmValue)
 	@IsString()
 	@MaxLength(64, { message: UTM_MESSAGE })
 	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })
@@ -36,6 +50,7 @@ export class PurchaseIntentDto {
 
 	@ApiPropertyOptional({ description: 'Meio da campanha (utm_medium)' })
 	@IsOptional()
+	@Transform(sanitizeUtmValue)
 	@IsString()
 	@MaxLength(64, { message: UTM_MESSAGE })
 	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })
@@ -43,6 +58,7 @@ export class PurchaseIntentDto {
 
 	@ApiPropertyOptional({ description: 'Nome da campanha (utm_campaign)' })
 	@IsOptional()
+	@Transform(sanitizeUtmValue)
 	@IsString()
 	@MaxLength(64, { message: UTM_MESSAGE })
 	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })

--- a/src/leads/dto/purchase-intent.dto.ts
+++ b/src/leads/dto/purchase-intent.dto.ts
@@ -1,5 +1,16 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsIn } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+	IsEmail,
+	IsMongoId,
+	IsOptional,
+	IsString,
+	Matches,
+	MaxLength,
+} from 'class-validator';
+
+const UTM_PATTERN = /^[\w.-]+$/;
+const UTM_MESSAGE =
+	'Use apenas letras, números, ponto, hífen ou underscore (máx. 64)';
 
 export class PurchaseIntentDto {
 	@ApiProperty({
@@ -10,9 +21,30 @@ export class PurchaseIntentDto {
 	email: string;
 
 	@ApiProperty({
-		description: 'Nome do plano que gerou o interesse',
-		example: 'Premium',
+		description: 'Id do plano que gerou o interesse',
+		example: '6995af0198591333bb0d4862',
 	})
-	@IsIn(['Premium', 'Global Investor'], { message: 'Plano inválido' })
-	planName: string;
+	@IsMongoId({ message: 'Plano inválido' })
+	planId: string;
+
+	@ApiPropertyOptional({ description: 'Origem da campanha (utm_source)' })
+	@IsOptional()
+	@IsString()
+	@MaxLength(64, { message: UTM_MESSAGE })
+	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })
+	utmSource?: string;
+
+	@ApiPropertyOptional({ description: 'Meio da campanha (utm_medium)' })
+	@IsOptional()
+	@IsString()
+	@MaxLength(64, { message: UTM_MESSAGE })
+	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })
+	utmMedium?: string;
+
+	@ApiPropertyOptional({ description: 'Nome da campanha (utm_campaign)' })
+	@IsOptional()
+	@IsString()
+	@MaxLength(64, { message: UTM_MESSAGE })
+	@Matches(UTM_PATTERN, { message: UTM_MESSAGE })
+	utmCampaign?: string;
 }

--- a/src/leads/leads.controller.spec.ts
+++ b/src/leads/leads.controller.spec.ts
@@ -10,12 +10,12 @@ describe('LeadsController', () => {
 
 		const result = await controller.capturePurchaseIntent({
 			email: 'investidor@example.com',
-			planName: 'Premium',
+			planId: '6995af0198591333bb0d4862',
 		});
 
 		expect(purchaseIntentService.captureIntent).toHaveBeenCalledWith({
 			email: 'investidor@example.com',
-			planName: 'Premium',
+			planId: '6995af0198591333bb0d4862',
 		});
 		expect(result).toEqual({ success: true });
 	});

--- a/src/leads/leads.controller.ts
+++ b/src/leads/leads.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from 'src/utils/constants';
 import { PurchaseIntentDto } from './dto/purchase-intent.dto';
 import { PurchaseIntentService } from './leads.service';
@@ -12,6 +12,7 @@ export class LeadsController {
 	@Public()
 	@Post('purchase-intent')
 	@ApiOkResponse({ schema: { example: { success: true } } })
+	@ApiBadRequestResponse({ description: 'Plano inválido' })
 	async capturePurchaseIntent(@Body() dto: PurchaseIntentDto) {
 		return this.purchaseIntentService.captureIntent(dto);
 	}

--- a/src/leads/leads.module.ts
+++ b/src/leads/leads.module.ts
@@ -1,10 +1,17 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { EmailModule } from 'src/notifications/email/email.module';
+import { SubscriptionModel } from 'src/subscription/schema';
 import { LeadsController } from './leads.controller';
 import { PurchaseIntentService } from './leads.service';
 
 @Module({
-	imports: [EmailModule],
+	imports: [
+		MongooseModule.forFeature([
+			{ name: 'Subscription', schema: SubscriptionModel.schema },
+		]),
+		EmailModule,
+	],
 	controllers: [LeadsController],
 	providers: [PurchaseIntentService],
 })

--- a/src/leads/leads.service.spec.ts
+++ b/src/leads/leads.service.spec.ts
@@ -1,149 +1,185 @@
-import { Logger } from '@nestjs/common';
 import { PurchaseIntentService } from './leads.service';
-import { EmailService } from 'src/notifications/email/email.service';
 
 describe('PurchaseIntentService', () => {
-	function buildService(overrides?: { resendContactsCreate?: jest.Mock }) {
+	const originalAudienceId = process.env.RESEND_AUDIENCE_ID;
+
+	beforeEach(() => {
+		process.env.RESEND_AUDIENCE_ID = 'audience_123';
+	});
+
+	afterAll(() => {
+		if (originalAudienceId === undefined) {
+			delete process.env.RESEND_AUDIENCE_ID;
+		} else {
+			process.env.RESEND_AUDIENCE_ID = originalAudienceId;
+		}
+	});
+
+	function makeSubscriptionModel(plan: unknown) {
+		return {
+			findById: jest.fn().mockResolvedValue(plan),
+		} as any;
+	}
+
+	const activePlan = {
+		_id: '6995af0198591333bb0d4862',
+		name: 'Pro',
+		isActive: true,
+	};
+
+	it('uses the plan name from the database, not from the request', async () => {
 		const emailService = {
 			sendPurchaseIntentConfirmationEmail: jest
 				.fn()
 				.mockResolvedValue(undefined),
-		} as unknown as EmailService;
-		const resendContactsCreate =
-			overrides?.resendContactsCreate ??
-			jest.fn().mockResolvedValue({ data: { id: 'contact_1' } });
-		const resendClient = { contacts: { create: resendContactsCreate } };
-
+		} as any;
+		const contacts = {
+			create: jest.fn().mockResolvedValue({ error: null }),
+			update: jest.fn().mockResolvedValue({ error: null }),
+		};
 		const service = new PurchaseIntentService(
 			emailService,
-			resendClient as any
+			makeSubscriptionModel(activePlan),
+			{ contacts } as any
 		);
-		return { service, emailService, resendContactsCreate };
-	}
-
-	it('adds the contact to the Resend audience with the plan name as a property', async () => {
-		const { service, resendContactsCreate } = buildService();
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
 
 		await service.captureIntent({
 			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
+			planId: '6995af0198591333bb0d4862',
+		} as any);
 
-		expect(resendContactsCreate).toHaveBeenCalledWith(
-			expect.objectContaining({
-				audienceId: 'audience_123',
+		expect(
+			emailService.sendPurchaseIntentConfirmationEmail
+		).toHaveBeenCalledWith('investidor@example.com', 'Pro');
+	});
+
+	it('rejects an unknown plan with a generic message', async () => {
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest.fn(),
+		} as any;
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel(null),
+			{ contacts: { create: jest.fn(), update: jest.fn() } } as any
+		);
+
+		await expect(
+			service.captureIntent({
 				email: 'investidor@example.com',
-				properties: expect.objectContaining({ planName: 'Premium' }),
+				planId: '6995af0198591333bb0d4862',
+			} as any)
+		).rejects.toThrow('Plano inválido');
+
+		expect(
+			emailService.sendPurchaseIntentConfirmationEmail
+		).not.toHaveBeenCalled();
+	});
+
+	it('rejects an inactive plan', async () => {
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest.fn(),
+		} as any;
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel({ ...activePlan, isActive: false }),
+			{ contacts: { create: jest.fn(), update: jest.fn() } } as any
+		);
+
+		await expect(
+			service.captureIntent({
+				email: 'investidor@example.com',
+				planId: '6995af0198591333bb0d4862',
+			} as any)
+		).rejects.toThrow('Plano inválido');
+	});
+
+	it('sends utm values to the contact properties', async () => {
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest
+				.fn()
+				.mockResolvedValue(undefined),
+		} as any;
+		const contacts = {
+			create: jest.fn().mockResolvedValue({ error: null }),
+			update: jest.fn().mockResolvedValue({ error: null }),
+		};
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel(activePlan),
+			{ contacts } as any
+		);
+
+		await service.captureIntent({
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+			utmSource: 'reddit',
+			utmCampaign: 'validacao',
+		} as any);
+
+		expect(contacts.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				properties: expect.objectContaining({
+					planName: 'Pro',
+					utmSource: 'reddit',
+					utmCampaign: 'validacao',
+				}),
 			})
 		);
 	});
 
-	it('sends the confirmation email', async () => {
-		const { service, emailService } = buildService();
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
-
-		await service.captureIntent({
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-
-		expect(
-			emailService.sendPurchaseIntentConfirmationEmail
-		).toHaveBeenCalledWith('investidor@example.com', 'Premium');
-	});
-
-	it('returns success even when the Resend contact creation throws', async () => {
-		const failingCreate = jest.fn().mockRejectedValue(new Error('Resend down'));
-		const { service } = buildService({ resendContactsCreate: failingCreate });
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
-
-		const result = await service.captureIntent({
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-
-		expect(result).toEqual({ success: true });
-	});
-
-	it('logs a warning and returns success when the Resend contact creation resolves with an error', async () => {
-		const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-		const errorCreate = jest
-			.fn()
-			.mockResolvedValue({ data: null, error: { message: 'some error' } });
-		const { service } = buildService({ resendContactsCreate: errorCreate });
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
-
-		const result = await service.captureIntent({
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-
-		expect(warnSpy).toHaveBeenCalledWith(
-			'Falha ao adicionar contato na audience do Resend: some error'
-		);
-		expect(result).toEqual({ success: true });
-
-		warnSpy.mockRestore();
-	});
-
-	it('returns success even when sending the confirmation email fails', async () => {
-		const { service, emailService } = buildService();
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
-		(
-			emailService.sendPurchaseIntentConfirmationEmail as jest.Mock
-		).mockRejectedValue(new Error('email provider down'));
-
-		const result = await service.captureIntent({
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-
-		expect(result).toEqual({ success: true });
-	});
-
-	it('skips the Resend contact call when RESEND_AUDIENCE_ID is not configured', async () => {
-		const { service, resendContactsCreate } = buildService();
-		delete process.env.RESEND_AUDIENCE_ID;
-
-		const result = await service.captureIntent({
-			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
-
-		expect(resendContactsCreate).not.toHaveBeenCalled();
-		expect(result).toEqual({ success: true });
-	});
-
-	it('logs a warning and skips the Resend contact call when RESEND_API_KEY is not configured but RESEND_AUDIENCE_ID is', async () => {
-		const originalApiKey = process.env.RESEND_API_KEY;
-		delete process.env.RESEND_API_KEY;
-		process.env.RESEND_AUDIENCE_ID = 'audience_123';
-
-		const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+	it('updates the existing contact when creation fails', async () => {
 		const emailService = {
 			sendPurchaseIntentConfirmationEmail: jest
 				.fn()
 				.mockResolvedValue(undefined),
-		} as unknown as EmailService;
+		} as any;
+		const contacts = {
+			create: jest
+				.fn()
+				.mockResolvedValue({ error: { message: 'Contact already exists' } }),
+			update: jest.fn().mockResolvedValue({ error: null }),
+		};
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel(activePlan),
+			{ contacts } as any
+		);
 
-		const service = new PurchaseIntentService(emailService);
+		await service.captureIntent({
+			email: 'investidor@example.com',
+			planId: '6995af0198591333bb0d4862',
+		} as any);
+
+		expect(contacts.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: 'investidor@example.com',
+				properties: expect.objectContaining({ planName: 'Pro' }),
+			})
+		);
+	});
+
+	it('still returns success when both create and update fail', async () => {
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest
+				.fn()
+				.mockResolvedValue(undefined),
+		} as any;
+		const contacts = {
+			create: jest.fn().mockRejectedValue(new Error('resend down')),
+			update: jest.fn().mockRejectedValue(new Error('resend down')),
+		};
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel(activePlan),
+			{ contacts } as any
+		);
 
 		const result = await service.captureIntent({
 			email: 'investidor@example.com',
-			planName: 'Premium',
-		});
+			planId: '6995af0198591333bb0d4862',
+		} as any);
 
-		expect(warnSpy).toHaveBeenCalledWith(
-			'RESEND_API_KEY não configurado; pulando criação de contato na audience'
-		);
 		expect(result).toEqual({ success: true });
-
-		warnSpy.mockRestore();
-		if (originalApiKey === undefined) {
-			delete process.env.RESEND_API_KEY;
-		} else {
-			process.env.RESEND_API_KEY = originalApiKey;
-		}
+		expect(emailService.sendPurchaseIntentConfirmationEmail).toHaveBeenCalled();
 	});
 });

--- a/src/leads/leads.service.spec.ts
+++ b/src/leads/leads.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { PurchaseIntentService } from './leads.service';
 
 describe('PurchaseIntentService', () => {
@@ -181,5 +182,42 @@ describe('PurchaseIntentService', () => {
 
 		expect(result).toEqual({ success: true });
 		expect(emailService.sendPurchaseIntentConfirmationEmail).toHaveBeenCalled();
+	});
+
+	it('logs an error stating the lead was NOT recorded when both create and update fail', async () => {
+		const errorSpy = jest
+			.spyOn(Logger.prototype, 'error')
+			.mockImplementation(() => undefined);
+
+		const emailService = {
+			sendPurchaseIntentConfirmationEmail: jest
+				.fn()
+				.mockResolvedValue(undefined),
+		} as any;
+		const contacts = {
+			create: jest.fn().mockRejectedValue(new Error('resend down')),
+			update: jest.fn().mockRejectedValue(new Error('resend down')),
+		};
+		const service = new PurchaseIntentService(
+			emailService,
+			makeSubscriptionModel(activePlan),
+			{ contacts } as any
+		);
+
+		try {
+			await service.captureIntent({
+				email: 'investidor@example.com',
+				planId: '6995af0198591333bb0d4862',
+			} as any);
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('investidor@example.com')
+			);
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringMatching(/NÃO registrado/)
+			);
+		} finally {
+			errorSpy.mockRestore();
+		}
 	});
 });

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -1,6 +1,14 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import {
+	BadRequestException,
+	Injectable,
+	Logger,
+	Optional,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 import { Resend } from 'resend';
 import { EmailService } from 'src/notifications/email/email.service';
+import { Subscription } from 'src/subscription/schema/subscription.model';
 import { PurchaseIntentDto } from './dto/purchase-intent.dto';
 
 @Injectable()
@@ -10,6 +18,8 @@ export class PurchaseIntentService {
 
 	constructor(
 		private readonly emailService: EmailService,
+		@InjectModel('Subscription')
+		private readonly subscriptionModel: Model<Subscription>,
 		@Optional() resendClient?: Pick<Resend, 'contacts'>
 	) {
 		const apiKey = process.env.RESEND_API_KEY;
@@ -18,40 +28,23 @@ export class PurchaseIntentService {
 	}
 
 	async captureIntent(dto: PurchaseIntentDto): Promise<{ success: true }> {
-		const audienceId = process.env.RESEND_AUDIENCE_ID;
-
-		if (audienceId && this.resendClient?.contacts) {
-			try {
-				const { error } = await this.resendClient.contacts.create({
-					audienceId,
-					email: dto.email,
-					properties: { planName: dto.planName },
-				} as Parameters<Resend['contacts']['create']>[0]);
-
-				if (error) {
-					this.logger.warn(
-						`Falha ao adicionar contato na audience do Resend: ${error?.message || error}`
-					);
-				}
-			} catch (error) {
-				this.logger.warn(
-					`Falha ao adicionar contato na audience do Resend: ${error?.message || error}`
-				);
-			}
-		} else if (!audienceId) {
-			this.logger.warn(
-				'RESEND_AUDIENCE_ID não configurado; pulando criação de contato na audience'
-			);
-		} else {
-			this.logger.warn(
-				'RESEND_API_KEY não configurado; pulando criação de contato na audience'
-			);
+		const plan = await this.subscriptionModel.findById(dto.planId);
+		if (!plan || !plan.isActive) {
+			// Mensagem genérica de propósito: este endpoint é anônimo e não
+			// deve confirmar se um id existe no banco.
+			throw new BadRequestException('Plano inválido');
 		}
+
+		// O nome vem do banco, nunca do corpo da requisição — é ele que será
+		// interpolado no e-mail enviado a partir do nosso domínio.
+		const planName = plan.name;
+
+		await this.registerContact(dto, planName);
 
 		try {
 			await this.emailService.sendPurchaseIntentConfirmationEmail(
 				dto.email,
-				dto.planName
+				planName
 			);
 		} catch (error) {
 			this.logger.warn(
@@ -60,5 +53,80 @@ export class PurchaseIntentService {
 		}
 
 		return { success: true };
+	}
+
+	private buildContactProperties(dto: PurchaseIntentDto, planName: string) {
+		const properties: Record<string, string> = { planName };
+		if (dto.utmSource) properties.utmSource = dto.utmSource;
+		if (dto.utmMedium) properties.utmMedium = dto.utmMedium;
+		if (dto.utmCampaign) properties.utmCampaign = dto.utmCampaign;
+		return properties;
+	}
+
+	private async registerContact(
+		dto: PurchaseIntentDto,
+		planName: string
+	): Promise<void> {
+		const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+		if (!audienceId) {
+			this.logger.warn(
+				'RESEND_AUDIENCE_ID não configurado; pulando criação de contato na audience'
+			);
+			return;
+		}
+		if (!this.resendClient?.contacts) {
+			this.logger.warn(
+				'RESEND_API_KEY não configurado; pulando criação de contato na audience'
+			);
+			return;
+		}
+
+		const properties = this.buildContactProperties(dto, planName);
+
+		try {
+			const { error } = await this.resendClient.contacts.create({
+				audienceId,
+				email: dto.email,
+				properties,
+			} as Parameters<Resend['contacts']['create']>[0]);
+
+			if (!error) return;
+
+			await this.updateContact(audienceId, dto.email, properties);
+		} catch (error) {
+			this.logger.warn(
+				`Falha ao criar contato na audience do Resend: ${error?.message || error}`
+			);
+			await this.updateContact(audienceId, dto.email, properties);
+		}
+	}
+
+	// Qualquer erro na criação cai para o update, em vez de identificar
+	// "contato já existe" pela mensagem: casar texto de erro é frágil entre
+	// versões da API. Se o erro era outro, o update falha, loga, e o fluxo
+	// segue igual.
+	private async updateContact(
+		audienceId: string,
+		email: string,
+		properties: Record<string, string>
+	): Promise<void> {
+		try {
+			const { error } = await this.resendClient.contacts.update({
+				audienceId,
+				email,
+				properties,
+			} as Parameters<Resend['contacts']['update']>[0]);
+
+			if (error) {
+				this.logger.warn(
+					`Falha ao atualizar contato na audience do Resend: ${error?.message || error}`
+				);
+			}
+		} catch (error) {
+			this.logger.warn(
+				`Falha ao atualizar contato na audience do Resend: ${error?.message || error}`
+			);
+		}
 	}
 }

--- a/src/leads/leads.service.ts
+++ b/src/leads/leads.service.ts
@@ -119,13 +119,13 @@ export class PurchaseIntentService {
 			} as Parameters<Resend['contacts']['update']>[0]);
 
 			if (error) {
-				this.logger.warn(
-					`Falha ao atualizar contato na audience do Resend: ${error?.message || error}`
+				this.logger.error(
+					`Lead NÃO registrado no Resend (create e update falharam) para ${email}: ${error?.message || error}`
 				);
 			}
 		} catch (error) {
-			this.logger.warn(
-				`Falha ao atualizar contato na audience do Resend: ${error?.message || error}`
+			this.logger.error(
+				`Lead NÃO registrado no Resend (create e update falharam) para ${email}: ${error?.message || error}`
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

The landing captures purchase intent — a visitor leaves an e-mail saying they want a plan — to validate demand before investing further in the product. Two defects made that measurement unreliable.

**The funnel returned 400 for one of the two paid plans.** The DTO validated `planName` against a hardcoded `@IsIn(['Premium', 'Global Investor'])`. Once the landing started rendering real backend plans, the real plan is named "Pro", so **"Assinar Pro" broke**. Widening the whitelist was not an option: `planName` is interpolated into a confirmation e-mail sent from our own domain, so unvalidated client text there is a phishing vector.

The fix inverts what travels. The client sends `planId`; the server resolves the plan from the database and the **database's** name is what reaches the e-mail and the CRM. That removes the vector structurally rather than by filtering, and it decouples the funnel from plan names — renaming "Pro" to "Investidor Pro" (TRA-18) will no longer break it.

**No channel attribution.** Only e-mail and plan were recorded, so leads could not be traced to the channel that produced them — which defeats the purpose of the experiment. Three optional UTM fields now ride along into the Resend contact properties (never into the e-mail body).

Repeat submissions now upsert the contact instead of failing, so one e-mail means one contact carrying the most recent interest.

### Invalid UTM values are dropped, not rejected

Worth calling out because it changed during review. The UTM pattern is ASCII-only and rejects spaces, so a self-authored link like `utm_campaign=validação_agosto` would have returned 400 and silently killed the conversions being measured. Rejecting buys no security over dropping the value — it only converts "lead without attribution" into "no lead". A `@Transform` now drops invalid values before validation; the validators stay as a harmless second layer.

## Test plan
- [x] Leads suite: 16/16 passing
- [x] Full suite: 510 passing, 2 pre-existing `ai/ai.controller.spec.ts` failures (red on `develop` too)
- [x] `tsc --noEmit` clean, `lint` clean
- [x] Task reviews + final whole-branch review (opus) + scoped re-review, all clean
- [x] Re-reviewer independently confirmed the transform runs before validation, so a dropped value cannot still be rejected

## Before deploying — please read

**1. This is a hard contract break. Server and web must ship together.** The companion web PR still posts `{email, planName}`. With `forbidNonWhitelisted: true`, a server-first deploy 400s every submission (`planName should not exist` plus missing `planId`), and a web-first deploy 400s against the old whitelist. There is no compatibility window.

**2. Confirm the three UTM contact properties exist in Resend first.** Resend models contact properties as a declared schema. If `utmSource`/`utmMedium`/`utmCampaign` are not registered in the workspace, `contacts.create` errors, the fallback `update` errors too, and **the lead is recorded nowhere while the visitor sees success** — a silently empty CRM across a whole campaign. This branch now logs that case at `error` level naming the lost e-mail, but it is far better to avoid it.

**3. The endpoint now depends on MongoDB.** Previously a Mongo outage still captured the lead in Resend; now the request fails. Unavoidable given the plan name has to come from somewhere, and the rest of the app needs Mongo anyway — but it is a real change in degradation behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)